### PR TITLE
Remove dev server proxy from Vite config

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,25 +14,6 @@ export default defineConfig(({ mode }) => ({
   server: {
     host: "::",
     port: 8080,
-
-    // Forward API calls to the Moontide proxy (only while running `npm run dev`)
-    proxy:
-      mode === "development"
-        ? {
-            "/noaa-stations": {
-              target: "http://localhost:3001",
-              changeOrigin: true,
-            },
-            "/noaa-station": {
-              target: "http://localhost:3001",
-              changeOrigin: true,
-            },
-            "/tides": {
-              target: "http://localhost:3001",
-              changeOrigin: true,
-            },
-          }
-        : undefined,
   },
 
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- remove proxy and localhost settings from `vite.config.ts`

## Testing
- `npm run lint` *(fails: several lint errors)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686802645ff4832d8550fe3f0597a806