### PR TITLE
Remove dev API switching logic

### DIFF
--- a/src/components/StationPicker.tsx
+++ b/src/components/StationPicker.tsx
@@ -5,7 +5,6 @@ import { Input } from '@/components/ui/input';
 import { Select, SelectTrigger, SelectContent, SelectItem, SelectValue } from '@/components/ui/select';
 import { toast } from 'sonner';
 import { Station } from '@/services/tide/stationService';
-import { IS_DEV } from '@/services/env';
 
 interface StationPickerProps {
   isOpen: boolean;
@@ -41,9 +40,8 @@ export default function StationPicker({ isOpen, stations, onSelect, onClose, cur
   const handleManualSearch = async () => {
     if (!manualId.trim()) return;
     try {
-      const url = IS_DEV
-        ? `/noaa-station/${manualId.trim()}`
-        : `https://api.tidesandcurrents.noaa.gov/mdapi/prod/webapi/stations/${manualId.trim()}.json`;
+      const url =
+        `https://api.tidesandcurrents.noaa.gov/mdapi/prod/webapi/stations/${manualId.trim()}.json`;
       const response = await fetch(url);
       if (!response.ok) {
         toast.error('Station not found');

--- a/src/services/tide/stationService.ts
+++ b/src/services/tide/stationService.ts
@@ -1,7 +1,6 @@
 // src/services/tide/stationService.ts
 
 import { cacheService } from '../cacheService';
-import { IS_DEV } from '../env';
 
 const NOAA_MDAPI_BASE = 'https://api.tidesandcurrents.noaa.gov/mdapi/prod/webapi';
 
@@ -29,9 +28,9 @@ export async function getStationsForLocation(
     return cached;
   }
 
-  const url = IS_DEV
-    ? `/noaa-stations?locationInput=${encodeURIComponent(userInput)}`
-    : `${NOAA_MDAPI_BASE}/stations.json?type=tidepredictions&name=${encodeURIComponent(userInput)}`;
+  const url = `${NOAA_MDAPI_BASE}/stations.json?type=tidepredictions&name=${encodeURIComponent(
+    userInput,
+  )}`;
 
   const response = await fetch(url);
   if (!response.ok) throw new Error("Unable to fetch station list.");
@@ -46,9 +45,7 @@ export async function getStationById(id: string): Promise<Station | null> {
   const cached = cacheService.get<Station>(key);
   if (cached) return cached;
 
-  const url = IS_DEV
-    ? `/noaa-station/${id}`
-    : `${NOAA_MDAPI_BASE}/stations/${id}.json`;
+  const url = `${NOAA_MDAPI_BASE}/stations/${id}.json`;
 
   const response = await fetch(url);
   if (!response.ok) throw new Error('Unable to fetch station');

--- a/src/services/tide/tideService.ts
+++ b/src/services/tide/tideService.ts
@@ -4,16 +4,11 @@
 /*  Live tide fetcher with tiered fallback: 6-min ➜ hourly ➜ high/low         */
 
 import { cacheService } from '../cacheService';
-import { IS_DEV } from '../env';
 
 type NoaaStation = { id: string; name: string; lat: number; lng: number };
 
-// Switch API base URL depending on environment. During development we hit the
-// local proxy to avoid CORS issues.
-const API_URL = IS_DEV
-  ? '/noaa-proxy'
-  : 'https://api.tidesandcurrents.noaa.gov';
-const BASE = `${API_URL}/api/prod/datagetter`;
+const BASE =
+  'https://api.tidesandcurrents.noaa.gov/api/prod/datagetter';
 const CACHE_TTL = 7 * 24 * 60 * 60 * 1000;
 
 type Units = 'english' | 'metric';

--- a/src/services/tideDataService.ts
+++ b/src/services/tideDataService.ts
@@ -3,14 +3,8 @@
 //  Fetch 7-day tide data for the given NOAA station
 //--------------------------------------------------------------
 
-import { IS_DEV } from './env';
-
-// Automatically switch API URL based on environment
-const API_URL = IS_DEV
-  ? '/noaa-proxy'
-  : 'https://api.tidesandcurrents.noaa.gov';
-
-const NOAA_DATA_BASE = `${API_URL}/api/prod/datagetter`;
+const NOAA_DATA_BASE =
+  'https://api.tidesandcurrents.noaa.gov/api/prod/datagetter';
 
 export interface Prediction {
   /** ISO date-time in the station’s local time zone (e.g. “2025-06-25T04:36:00”) */
@@ -39,20 +33,18 @@ export async function getTideData(
 
   const format = (d: Date) => d.toISOString().slice(0, 10).replace(/-/g, '');
 
-  const url = IS_DEV
-    ? `/tides?stationId=${stationId}&date=${yyyymmdd}`
-    : `${NOAA_DATA_BASE}?${new URLSearchParams({
-        product: 'predictions',
-        application: 'LunarWaveWatcher',
-        format: 'json',
-        datum: 'MLLW',
-        time_zone: 'lst_ldt',
-        interval: 'hilo',
-        units: 'english',
-        station: stationId,
-        begin_date: format(start),
-        end_date: format(end),
-      }).toString()}`;
+  const url = `${NOAA_DATA_BASE}?${new URLSearchParams({
+    product: 'predictions',
+    application: 'LunarWaveWatcher',
+    format: 'json',
+    datum: 'MLLW',
+    time_zone: 'lst_ldt',
+    interval: 'hilo',
+    units: 'english',
+    station: stationId,
+    begin_date: format(start),
+    end_date: format(end),
+  }).toString()}`;
   console.log('📡 getTideData fetch:', { stationId, url });
   let raw: any;
   try {


### PR DESCRIPTION
## Summary
- remove `IS_DEV` checks in tide data services and components
- always call NOAA APIs directly

## Testing
- `npm run lint` *(fails: Unexpected any errors)*

------
https://chatgpt.com/codex/tasks/task_e_6868031d1868832d879d8cb0cf5c2335