### PR TITLE
Auto-select single tide station

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ Read more here: [Setting up a custom domain](https://docs.lovable.dev/tips-trick
 ## Where is NOAA tide data stored?
 
 The mobile APK functions primarily as a frontend. It fetches live NOAA data at
-runtime, but the results are cached locally using SQLite (or
-`localStorage`/`SharedPreferences` on platforms that do not support SQLite). This
-allows the last retrieved tide information to remain available when offline.
+runtime **directly from** `https://api.tidesandcurrents.noaa.gov` without any
+intermediate servers. The results are cached locally using SQLite (or
+`localStorage`/`SharedPreferences` on platforms that do not support SQLite).
+This allows the last retrieved tide information to remain available when
+offline.

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -77,7 +77,12 @@ const Index = () => {
           toast.error('No NOAA stations found for this location.');
         } else {
           setAvailableStations(stations);
-          setShowStationPicker(true);
+          if (stations.length === 1) {
+            setSelectedStation(stations[0]);
+            setShowStationPicker(false);
+          } else {
+            setShowStationPicker(true);
+          }
         }
       })
       .catch(() => {


### PR DESCRIPTION
## Summary
- clarify that the app fetches NOAA data directly
- auto-select the only available station so the tide data loads automatically

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68683d79ce04832da5e0f0203a65f7df