### PR TITLE
Add Android debug build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "vite build",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "android:debug": "npm run build && npx cap sync android && cd android && ./gradlew assembleDebug"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",


### PR DESCRIPTION
## Summary
- add `android:debug` script to handle Android build with capacitor

## Testing
- `npm run build`
- `npm run lint` *(fails: unexpected any errors)*

------
https://chatgpt.com/codex/tasks/task_e_68697b04ad9c832d96b77eb57aa0af35