### PR TITLE
Fix Android build workflow

### DIFF
--- a/.github/workflows/android-debug.yml
+++ b/.github/workflows/android-debug.yml
@@ -38,17 +38,21 @@ jobs:
             npx cap add android
           fi
 
-      # 5) Copy web assets & plugins into android/
+      # 5) Build the web assets used by Capacitor
+      - name: Build web assets
+        run: npm run build
+
+      # 6) Copy web assets & plugins into android/
       - name: Sync Capacitor
         run: npx cap sync android
 
-      # 6) Build the debug APK
+      # 7) Build the debug APK
       - name: Build debug APK
         run: |
           cd android
           ./gradlew assembleDebug
 
-      # 7) Upload the APK artifact
+      # 8) Upload the APK artifact
       - name: Upload APK artifact
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
## Summary
- ensure production build is run before syncing Capacitor for Android

## Testing
- `npm run lint` *(fails: Unexpected any and require style import errors)*

------
https://chatgpt.com/codex/tasks/task_e_686980c6f0a0832dafd2fd701f258947