### PR TITLE
Improve station search with coordinate lookup

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -69,7 +69,7 @@ const Index = () => {
 
     const input = currentLocation.zipCode || currentLocation.cityState || currentLocation.name;
     setIsStationLoading(true);
-    getStationsForLocationInput(input)
+    getStationsForLocationInput(input, currentLocation.lat, currentLocation.lng)
       .then((stations) => {
         if (!stations || stations.length === 0) {
           setAvailableStations([]);

--- a/src/services/locationService.ts
+++ b/src/services/locationService.ts
@@ -1,11 +1,16 @@
 // src/services/locationService.ts
 
-import { getStationsForUserLocation } from "./noaaService";
+import { getStationsForUserLocation } from './noaaService';
 import { Station, getStationById as fetchStationById } from "./tide/stationService";
 
 // Returns true if no stations for user location, false otherwise
-export async function isInlandLocation(userInput: string, stationId?: string): Promise<boolean> {
-  const stations = await getStationsForUserLocation(userInput);
+export async function isInlandLocation(
+  userInput: string,
+  lat?: number,
+  lon?: number,
+  stationId?: string,
+): Promise<boolean> {
+  const stations = await getStationsForUserLocation(userInput, lat, lon);
   if (stationId) {
     return !stations.some((station) => station.id === stationId);
   }
@@ -13,8 +18,12 @@ export async function isInlandLocation(userInput: string, stationId?: string): P
 }
 
 // Returns all stations for the user's location input
-export async function getStationsForLocationInput(userInput: string): Promise<Station[]> {
-  return getStationsForUserLocation(userInput);
+export async function getStationsForLocationInput(
+  userInput: string,
+  lat?: number,
+  lon?: number,
+): Promise<Station[]> {
+  return getStationsForUserLocation(userInput, lat, lon);
 }
 
 export async function getStationById(id: string): Promise<Station | null> {

--- a/src/services/noaaService.ts
+++ b/src/services/noaaService.ts
@@ -1,10 +1,21 @@
 // src/services/noaaService.ts
 
-import { getStationsForLocation } from "./tide/stationService";
-import { Station } from "./tide/stationService";
+import {
+  getStationsForLocation,
+  getStationsNearCoordinates,
+} from './tide/stationService';
+import { Station } from './tide/stationService';
 
 // Always use dynamic live lookup for NOAA stations
-export async function getStationsForUserLocation(userInput: string): Promise<Station[]> {
+export async function getStationsForUserLocation(
+  userInput: string,
+  lat?: number,
+  lon?: number,
+): Promise<Station[]> {
+  if (lat != null && lon != null) {
+    const nearby = await getStationsNearCoordinates(lat, lon);
+    if (nearby.length > 0) return nearby;
+  }
   return getStationsForLocation(userInput);
 }
 

--- a/src/services/tide/stationService.ts
+++ b/src/services/tide/stationService.ts
@@ -40,6 +40,28 @@ export async function getStationsForLocation(
   return stations;
 }
 
+export async function getStationsNearCoordinates(
+  lat: number,
+  lon: number,
+  radiusKm = 100,
+): Promise<Station[]> {
+  const key = `stations:${lat.toFixed(3)},${lon.toFixed(3)},${radiusKm}`;
+
+  const cached = cacheService.get<Station[]>(key);
+  if (cached) {
+    return cached;
+  }
+
+  const url = `${NOAA_MDAPI_BASE}/stations.json?type=tidepredictions&lat=${lat}&lon=${lon}&radius=${radiusKm}`;
+
+  const response = await fetch(url);
+  if (!response.ok) throw new Error('Unable to fetch station list.');
+  const data = await response.json();
+  const stations = data.stations || [];
+  cacheService.set(key, stations, STATION_CACHE_TTL);
+  return stations;
+}
+
 export async function getStationById(id: string): Promise<Station | null> {
   const key = `station:${id}`;
   const cached = cacheService.get<Station>(key);


### PR DESCRIPTION
## Summary
- allow fetching NOAA stations near provided coordinates
- expose coordinate search via noaaService and locationService
- use lat/lon data when determining available stations on the dashboard

## Testing
- `npm run lint` *(fails: Unexpected any)*

------
https://chatgpt.com/codex/tasks/task_e_6869859d7f2c832dbd1948da8442a4f1