### PR TITLE
Fix station selection coordinate handling

### DIFF
--- a/src/components/LocationManager.tsx
+++ b/src/components/LocationManager.tsx
@@ -77,8 +77,8 @@ const LocationManager = ({ setCurrentLocation, setShowLocationSelector }: Locati
         country: "USA",
         zipCode: location.zipCode || '',
         cityState: `${location.city}, ${location.state}`,
-        lat: location.lat || 0,
-        lng: location.lng || 0
+        lat: location.lat ?? null,
+        lng: location.lng ?? null
       };
       
       console.log('🔄 LocationManager: Converting and setting location');

--- a/src/components/LocationSearchInput.tsx
+++ b/src/components/LocationSearchInput.tsx
@@ -161,8 +161,8 @@ export default function LocationSearchInput({
           country: 'USA',
           zipCode: '', // No ZIP for manual entry
           cityState,
-          lat: 0, // Manual entries don't have coordinates
-          lng: 0,
+          lat: null, // Manual entries don't have coordinates
+          lng: null,
         };
       }
       

--- a/src/components/LocationSelector.tsx
+++ b/src/components/LocationSelector.tsx
@@ -11,13 +11,13 @@ import { Station } from '@/services/tide/stationService';
 
 // Keep the SavedLocation interface for backward compatibility
 export interface SavedLocation {
-  id?: string;         
-  name: string;        
-  country?: string;    
-  zipCode: string;     
-  cityState: string;   
-  lat: number;
-  lng: number;
+  id?: string;
+  name: string;
+  country?: string;
+  zipCode: string;
+  cityState: string;
+  lat: number | null;
+  lng: number | null;
 }
 
 export default function LocationSelector({
@@ -62,8 +62,8 @@ export default function LocationSelector({
       country: 'USA',
       zipCode: location.zipCode,
       cityState: `${location.city}, ${location.state}`,
-      lat: location.lat || 0,
-      lng: location.lng || 0
+      lat: location.lat ?? null,
+      lng: location.lng ?? null
     };
 
     onSelect(savedLocation);
@@ -88,8 +88,8 @@ export default function LocationSelector({
       country: 'USA',
       zipCode: location.zipCode,
       cityState: `${location.city}, ${location.state}`,
-      lat: location.lat || 0,
-      lng: location.lng || 0
+      lat: location.lat ?? null,
+      lng: location.lng ?? null
     };
 
     onSelect(savedLocation);

--- a/src/components/MoonPhase.tsx
+++ b/src/components/MoonPhase.tsx
@@ -10,6 +10,7 @@ import SolarInfo from './SolarInfo';
 import OnboardingInfo from './OnboardingInfo';
 import LocationInfo from './LocationInfo';
 import { LocationData } from '@/types/locationTypes';
+import { SavedLocation } from './LocationSelector';
 
 type MoonPhaseProps = {
   phase: string;
@@ -18,7 +19,7 @@ type MoonPhaseProps = {
   moonset: string;
   date: string;
   className?: string;
-  currentLocation?: any;
+  currentLocation?: (SavedLocation & { id: string; country: string }) | null;
   stationName?: string | null;
   stationId?: string | null;
   error?: string | null;
@@ -62,8 +63,8 @@ const MoonPhase = ({
   const fullMoonName = isFullMoon(actualPhase) ? getFullMoonName(currentDate) : null;
 
   // Calculate solar times using location coordinates or defaults
-  const lat = currentLocation?.lat || 41.4353; // Default to Newport, RI
-  const lng = currentLocation?.lng || -71.4616;
+  const lat = currentLocation?.lat ?? 41.4353; // Default to Newport, RI
+  const lng = currentLocation?.lng ?? -71.4616;
 
   const solarTimes = React.useMemo(
     () => calculateSolarTimes(currentDate, lat, lng),

--- a/src/components/StationPicker.tsx
+++ b/src/components/StationPicker.tsx
@@ -82,7 +82,7 @@ export default function StationPicker({ isOpen, stations, onSelect, onClose, cur
             <SelectTrigger>
               <SelectValue placeholder="Choose station" />
             </SelectTrigger>
-            <SelectContent className="max-h-40">
+            <SelectContent className="max-h-40 max-w-[90vw]">
               {stations.map((s) => (
                 <SelectItem key={s.id} value={s.id}>
                   {s.name}

--- a/src/hooks/useLocationState.tsx
+++ b/src/hooks/useLocationState.tsx
@@ -24,8 +24,8 @@ function getInitialLocation(): (SavedLocation & { id: string; country: string })
         country: 'USA',
         zipCode: newLocation.zipCode || '',
         cityState: `${newLocation.city}, ${newLocation.state}`,
-        lat: newLocation.lat || 0,
-        lng: newLocation.lng || 0,
+        lat: newLocation.lat ?? null,
+        lng: newLocation.lng ?? null,
       };
     }
 


### PR DESCRIPTION
## Summary
- preserve null lat/lon values in location state
- ensure SavedLocation allows null coordinates
- avoid passing 0/0 coordinates when selecting a station
- constrain StationPicker width on mobile

## Testing
- `npm run -s build`
- `npx eslint src/components/LocationManager.tsx src/components/LocationSearchInput.tsx src/components/LocationSelector.tsx src/components/MoonPhase.tsx src/hooks/useLocationState.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68698a4bea20832da3a3a5a1213319b3