### PR TITLE
Fix dropdown width on mobile

### DIFF
--- a/src/components/LocationSelector.tsx
+++ b/src/components/LocationSelector.tsx
@@ -113,7 +113,7 @@ export default function LocationSelector({
         </button>
       </DropdownMenuTrigger>
 
-      <DropdownMenuContent className="w-80 p-0 bg-background border shadow-lg z-50">
+      <DropdownMenuContent className="w-[90vw] max-w-md p-0 bg-background border shadow-lg z-50 sm:w-80">
         {showAddNew ? (
           <div className="p-4">
             <div className="flex items-center gap-2 mb-4">


### PR DESCRIPTION
## Summary
- make LocationSelector dropdown width responsive so it fits small screens

## Testing
- `npm run lint` *(fails: unexpected any type errors)*

------
https://chatgpt.com/codex/tasks/task_e_686990d79b40832dbd144346e3988e7c