### PR TITLE
Fix mobile layout for header actions

### DIFF
--- a/src/components/AppHeader.tsx
+++ b/src/components/AppHeader.tsx
@@ -30,8 +30,8 @@ export default function AppHeader({
   return (
     <header className="py-4 px-4 sm:px-6 lg:px-8">
       <div className="container mx-auto">
-        <div className="flex items-center justify-between">
-          <div className="flex items-center">
+        <div className="flex flex-wrap items-center justify-between gap-y-2">
+          <div className="flex items-center w-full justify-center sm:w-auto sm:justify-start">
             <CloudMoon className="h-8 w-8 text-moon-primary mr-2" />
             <h1 className="text-2xl font-bold bg-gradient-to-r from-moon-primary to-moon-blue bg-clip-text text-transparent">
               MoonTide
@@ -42,7 +42,7 @@ export default function AppHeader({
               </span>
             )}
           </div>
-          <div className="flex items-center gap-3">
+          <div className="flex items-center gap-2 flex-wrap w-full justify-center sm:w-auto sm:justify-end">
             <Link to="/fishing-calendar">
               <Button variant="outline" className="flex items-center gap-1">
                 <Calendar className="h-4 w-4" />


### PR DESCRIPTION
## Summary
- allow header container to wrap items
- stack buttons under the logo on narrow screens

## Testing
- `npm run lint` *(fails: Unexpected any, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68699ee71050832da1e1684f233e7524