### PR TITLE
Fix calendar header layout

### DIFF
--- a/src/components/fishing/FishingCalendarHeader.tsx
+++ b/src/components/fishing/FishingCalendarHeader.tsx
@@ -12,32 +12,34 @@ type FishingCalendarHeaderProps = {
   stationName: string | null;
 };
 
-const FishingCalendarHeader: React.FC<FishingCalendarHeaderProps> = ({ 
-  currentLocation, 
-  stationName 
+const FishingCalendarHeader: React.FC<FishingCalendarHeaderProps> = ({
+  currentLocation,
+  stationName,
 }) => {
   return (
-    <header className="py-4 px-4 sm:px-6 lg:px-8">
+    <header className="py-4 px-4 sm:px-6 lg:px-8 max-w-full">
       <div className="container mx-auto">
-        <div className="flex items-center justify-between">
+        <div className="flex flex-wrap items-center justify-between gap-y-2">
           <div className="flex items-center">
             <CloudMoon className="h-8 w-8 text-moon-primary mr-2" />
-            <h1 className="text-2xl font-bold bg-gradient-to-r from-moon-primary to-moon-blue bg-clip-text text-transparent">
+            <h1 className="ml-1 text-2xl font-bold bg-gradient-to-r from-moon-primary to-moon-blue bg-clip-text text-transparent">
               Calendar
             </h1>
           </div>
-          <div className="flex items-center gap-3">
-            <span className="text-sm font-medium hidden md:inline">
-              {currentLocation
-                ? <>
-                    {currentLocation.name}, {currentLocation.country}
-                    {currentLocation.zipCode && ` (${currentLocation.zipCode})`}
-                    {stationName && ` - ${stationName}`}
-                  </>
-                : "Location not set"}
+          <div className="flex items-center gap-3 w-full sm:w-auto justify-between sm:justify-end">
+            <span className="text-sm font-medium hidden md:inline truncate">
+              {currentLocation ? (
+                <>
+                  {currentLocation.name}, {currentLocation.country}
+                  {currentLocation.zipCode && ` (${currentLocation.zipCode})`}
+                  {stationName && ` - ${stationName}`}
+                </>
+              ) : (
+                "Location not set"
+              )}
             </span>
-            <Link to="/">
-              <Button variant="ghost" className="flex items-center gap-1">
+            <Link to="/" className="shrink-0">
+              <Button variant="ghost" className="flex items-center gap-1 px-2">
                 <ArrowLeft className="h-4 w-4" /> Back to Dashboard
               </Button>
             </Link>


### PR DESCRIPTION
## Summary
- adjust layout of fishing calendar header so it wraps on small screens
- ensure back link and title are padded and don't overflow

## Testing
- `npm run lint` *(fails: Unexpected any and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6869a6ee3558832d89469feb557c0df0