### PR TITLE
Fix station filtering & dropdown

### DIFF
--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -73,7 +73,7 @@ const SelectContent = React.forwardRef<
     <SelectPrimitive.Content
       ref={ref}
       className={cn(
-        "relative z-50 max-h-80 min-w-[8rem] overflow-y-auto rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        "relative z-[60] max-h-80 min-w-[8rem] overflow-y-auto rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
         position === "popper" &&
           "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
         className

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -74,7 +74,7 @@ const Index = () => {
         if (!stations || stations.length === 0) {
           setAvailableStations([]);
           setShowStationPicker(false);
-          toast.error('No NOAA stations found for this location.');
+          toast.error('No tide stations found nearby — try another ZIP or location.');
         } else {
           const sorted = sortStationsForDefault(
             stations,


### PR DESCRIPTION
## Summary
- filter & sort stations within 100km that support tide predictions
- show better no-station message
- ensure select dropdown overlays modal

## Testing
- `npm run lint` *(fails: 33 errors)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6869acf487a8832dbd6188d3a8194c9c