### PR TITLE
Fix tide station selection for ZIP lookup

### DIFF
--- a/src/hooks/useTideData.tsx
+++ b/src/hooks/useTideData.tsx
@@ -80,6 +80,10 @@ export const useTideData = ({ location, station }: UseTideDataParams): UseTideDa
       setIsLoading(true);
       setError(null);
       setIsInland(false);
+      console.log('🚀 Tide data fetch triggered for', {
+        location,
+        stationId: station?.id,
+      });
 
       try {
         const chosen = station;

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -68,6 +68,7 @@ const Index = () => {
     if (locationChanged && selectedStation) setSelectedStation(null);
 
     const input = currentLocation.zipCode || currentLocation.cityState || currentLocation.name;
+    console.log('📍 Station lookup for:', { input, lat: currentLocation.lat, lon: currentLocation.lng });
     setIsStationLoading(true);
     getStationsForLocationInput(input, currentLocation.lat, currentLocation.lng)
       .then((stations) => {
@@ -83,8 +84,17 @@ const Index = () => {
             currentLocation.cityState?.split(',')[0],
           );
           setAvailableStations(sorted);
-          if (sorted.length === 1) {
+
+          const reference = sorted.find((s) => (s as any).type === 'R');
+
+          if (reference) {
+            console.log('⚓ Auto-selected reference station:', reference);
+            setSelectedStation(reference);
+            console.log('📡 stationId set to', reference.id);
+            setShowStationPicker(false);
+          } else if (sorted.length === 1) {
             setSelectedStation(sorted[0]);
+            console.log('📡 stationId set to', sorted[0].id);
             setShowStationPicker(false);
           } else {
             setShowStationPicker(true);


### PR DESCRIPTION
## Summary
- auto-select closest reference tide station when a location is chosen
- log station lookup and tide data fetch details

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6869be046b10832d9bf26661de7ba322