### PR TITLE
Update station selection logic

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -85,18 +85,11 @@ const Index = () => {
           );
           setAvailableStations(sorted);
 
-          const reference = sorted.find((s) => (s as any).type === 'R');
-
-          if (reference) {
-            console.log('⚓ Auto-selected reference station:', reference);
-            setSelectedStation(reference);
-            console.log('📡 stationId set to', reference.id);
-            setShowStationPicker(false);
-          } else if (sorted.length === 1) {
+          if (sorted.length === 1) {
             setSelectedStation(sorted[0]);
             console.log('📡 stationId set to', sorted[0].id);
             setShowStationPicker(false);
-          } else {
+          } else if (sorted.length > 1) {
             setShowStationPicker(true);
           }
         }


### PR DESCRIPTION
## Summary
- simplify station auto-selection behavior in index page
- display station picker for multiple options

## Testing
- `npm run lint` *(fails: 33 errors, 13 warnings)*
- `npm run test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_686a5b3d55d0832dbff39d5bf3bcdb54