### PR TITLE
Support station name searches

### DIFF
--- a/src/components/AppHeader.tsx
+++ b/src/components/AppHeader.tsx
@@ -11,6 +11,7 @@ interface AppHeaderProps {
   stationName: string | null;
   onLocationChange: (location: SavedLocation) => void;
   onStationSelect?: (station: Station) => void;
+  onStationsFound?: (stations: Station[]) => void;
   onLocationClear?: () => void;
   hasError?: boolean;
   forceShowLocationSelector?: boolean;
@@ -22,6 +23,7 @@ export default function AppHeader({
   stationName,
   onLocationChange,
   onStationSelect,
+  onStationsFound,
   onLocationClear,
   hasError,
   forceShowLocationSelector,
@@ -58,6 +60,7 @@ export default function AppHeader({
             <LocationSelector
               onSelect={onLocationChange}
               onStationSelect={onStationSelect}
+              onStationsFound={onStationsFound}
               forceOpen={forceShowLocationSelector}
               onClose={onLocationSelectorClose}
             />

--- a/src/components/EnhancedLocationInput.tsx
+++ b/src/components/EnhancedLocationInput.tsx
@@ -15,13 +15,14 @@ interface EnhancedLocationInputProps {
   onStationSelect?: (station: Station) => void;
   onLocationClear?: () => void;
   onClose: () => void;
+  onStationsFound?: (stations: Station[]) => void;
 }
 
 interface SavedLocationWithNickname extends LocationData {
   nickname?: string;
 }
 
-export default function EnhancedLocationInput({ onLocationSelect, onStationSelect, onLocationClear, onClose }: EnhancedLocationInputProps) {
+export default function EnhancedLocationInput({ onLocationSelect, onStationSelect, onLocationClear, onClose, onStationsFound }: EnhancedLocationInputProps) {
   const [savedLocations, setSavedLocations] = useState<SavedLocationWithNickname[]>([]);
   const [editingNickname, setEditingNickname] = useState<string | null>(null);
   const [nicknameInput, setNicknameInput] = useState('');
@@ -91,6 +92,7 @@ export default function EnhancedLocationInput({ onLocationSelect, onStationSelec
         onLocationSelect={handleLocationSelect}
         onStationSelect={onStationSelect}
         onClose={onClose}
+        onStationsFound={onStationsFound}
         placeholder="02840 or Newport, RI"
       />
       <div className="-mt-2 space-y-2">

--- a/src/components/LocationSelector.tsx
+++ b/src/components/LocationSelector.tsx
@@ -25,13 +25,15 @@ export default function LocationSelector({
   onLocationClear,
   forceOpen,
   onClose,
-  onStationSelect
+  onStationSelect,
+  onStationsFound
 }: {
   onSelect: (loc: SavedLocation) => void;
   onLocationClear?: () => void;
   forceOpen?: boolean;
   onClose?: () => void;
   onStationSelect?: (station: Station) => void;
+  onStationsFound?: (stations: Station[]) => void;
 }) {
   const [isOpen, setIsOpen] = useState(false);
   const [showAddNew, setShowAddNew] = useState(false);
@@ -132,6 +134,7 @@ export default function LocationSelector({
               onStationSelect={onStationSelect}
               onLocationClear={handleLocationClear}
               onClose={() => setIsOpen(false)}
+              onStationsFound={onStationsFound}
             />
           </div>
         ) : (

--- a/src/components/UnifiedLocationInput.tsx
+++ b/src/components/UnifiedLocationInput.tsx
@@ -10,6 +10,7 @@ interface UnifiedLocationInputProps {
   onLocationSelect: (location: LocationData) => void;
   onStationSelect?: (station: Station) => void;
   onClose?: () => void;
+  onStationsFound?: (stations: Station[]) => void;
   placeholder?: string;
   autoFocus?: boolean;
 }
@@ -18,14 +19,19 @@ export default function UnifiedLocationInput({
   onLocationSelect,
   onStationSelect,
   onClose,
+  onStationsFound,
   placeholder = "ZIP, City State, or NOAA Station Name/ID",
   autoFocus = true
 }: UnifiedLocationInputProps) {
-  const { isLoading: searchLoading, handleLocationSearch } = useLocationSearch({
+  const { isLoading: searchLoading, handleLocationSearch, stations } = useLocationSearch({
     onLocationSelect,
     onStationSelect,
     onClose
   });
+
+  React.useEffect(() => {
+    if (onStationsFound) onStationsFound(stations);
+  }, [stations, onStationsFound]);
 
   const { isLoading: gpsLoading, handleGPSRequest } = useGPSLocation({
     onLocationSelect,


### PR DESCRIPTION
## Summary
- fetch stations for station name queries in `useLocationSearch`
- surface found stations through `UnifiedLocationInput`
- plumb station lists up through `AppHeader` and into `Index`
- show these stations in `StationPicker` when searching by name

## Testing
- `npm run lint` *(fails: Unexpected any, require-imports)*

------
https://chatgpt.com/codex/tasks/task_e_686a5b412abc832d8c697febcedd1011