### PR TITLE
Add detailed logging and auto-select nearest tide station

### DIFF
--- a/src/hooks/useLocationSearch.tsx
+++ b/src/hooks/useLocationSearch.tsx
@@ -121,6 +121,7 @@ export const useLocationSearch = ({ onLocationSelect, onStationSelect, onClose }
         timestamp: Date.now()
       };
       console.log('✅ ZIP lookup successful:', location);
+      console.log('📌 Geocoded coordinates:', location.lat, location.lng);
       return location;
     }
     return null;
@@ -141,6 +142,7 @@ export const useLocationSearch = ({ onLocationSelect, onStationSelect, onClose }
         timestamp: Date.now()
       };
       console.log('✅ City/State/ZIP verification successful:', location);
+      console.log('📌 Geocoded coordinates:', location.lat, location.lng);
       return location;
     }
     return null;
@@ -161,6 +163,7 @@ export const useLocationSearch = ({ onLocationSelect, onStationSelect, onClose }
         timestamp: Date.now()
       };
       console.log('✅ City/State geocoding successful:', location);
+      console.log('📌 Geocoded coordinates:', location.lat, location.lng);
       return location;
     } else {
       // Fallback to manual entry (no coordinates)

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -70,7 +70,13 @@ const Index = () => {
         currentLocation.cityState?.split(',')[0],
       );
       setAvailableStations(sorted);
-      setShowStationPicker(true); // ← always let user choose
+      if (!selectedStation && sorted.length > 0) {
+        console.log('🎯 Auto-selecting station from incoming list:', sorted[0]);
+        setSelectedStation(sorted[0]);
+        setShowStationPicker(sorted.length > 1);
+      } else {
+        setShowStationPicker(true);
+      }
       setIncomingStations(null);
       return;
     }
@@ -102,7 +108,13 @@ const Index = () => {
           );
           console.log('📈 Sorted station IDs:', sorted.map(s => s.id));
           setAvailableStations(sorted);
-          setShowStationPicker(true); // ← always let user choose
+          if (!selectedStation && sorted.length > 0) {
+            console.log('🎯 Auto-selecting station:', sorted[0]);
+            setSelectedStation(sorted[0]);
+            setShowStationPicker(sorted.length > 1);
+          } else {
+            setShowStationPicker(true);
+          }
         }
       })
       .catch(() => {

--- a/src/services/locationService.ts
+++ b/src/services/locationService.ts
@@ -23,6 +23,7 @@ export async function getStationsForLocationInput(
   lat?: number,
   lon?: number,
 ): Promise<Station[]> {
+  console.log('📡 getStationsForLocationInput:', { userInput, lat, lon });
   return getStationsForUserLocation(userInput, lat, lon);
 }
 

--- a/src/services/noaaService.ts
+++ b/src/services/noaaService.ts
@@ -12,6 +12,11 @@ export async function getStationsForUserLocation(
   lat?: number,
   lon?: number,
 ): Promise<Station[]> {
+  console.log('🔎 getStationsForUserLocation:', {
+    userInput,
+    lat,
+    lon,
+  });
   if (lat != null && lon != null) {
     const nearby = await getStationsNearCoordinates(lat, lon);
     if (nearby.length > 0) return nearby;

--- a/src/services/tide/stationService.ts
+++ b/src/services/tide/stationService.ts
@@ -63,6 +63,10 @@ export async function getStationsNearCoordinates(
   const data = await response.json();
   const rawStations: Station[] = data.stations || [];
   console.log('📄 Raw stations returned:', rawStations.length);
+  console.log(
+    '📝 Raw station IDs:',
+    rawStations.map((s: any) => `${s.id}:${s.name}`).join(', '),
+  );
 
   const { getDistanceKm } = require('./geo');
 
@@ -90,6 +94,10 @@ export async function getStationsNearCoordinates(
 
   cacheService.set(key, stations, STATION_CACHE_TTL);
   console.log('✅ Filtered stations count:', stations.length);
+  console.log(
+    '🏅 Sorted station order:',
+    stations.map((s) => `${s.id}:${s.name}`).join(', '),
+  );
   return stations;
 }
 


### PR DESCRIPTION
## Summary
- add console logs for geocoding results and station searches
- trace NOAA station fetches by listing IDs and order
- automatically pick the first station after station search

## Testing
- `npm run lint` *(fails: Unexpected any, require-imports)*

------
https://chatgpt.com/codex/tasks/task_e_686a8163eb34832d8743cca8983d2cb5