### PR TITLE
Add detailed station fetch logging

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -94,8 +94,11 @@ const Index = () => {
     setIsStationLoading(true);
     getStationsForLocationInput(input, currentLocation.lat, currentLocation.lng)
       .then((stations) => {
+        console.log('📡 Stations API response payload:', stations);
         console.log('📡 Stations API returned', stations.length, 'items');
+        console.log(stations.length > 0 ? '✅ Stations found' : '❌ No stations found');
         if (!stations || stations.length === 0) {
+          console.log('🏁 Final availableStations: []');
           setAvailableStations([]);
           setShowStationPicker(false);
           toast.error('No tide stations found nearby — try another ZIP or location.');
@@ -107,6 +110,7 @@ const Index = () => {
             currentLocation.cityState?.split(',')[0],
           );
           console.log('📈 Sorted station IDs:', sorted.map(s => s.id));
+          console.log('🏁 Final availableStations:', sorted);
           setAvailableStations(sorted);
           if (!selectedStation && sorted.length > 0) {
             console.log('🎯 Auto-selecting station:', sorted[0]);

--- a/src/services/tide/stationService.ts
+++ b/src/services/tide/stationService.ts
@@ -35,8 +35,13 @@ export async function getStationsForLocation(
   const response = await fetch(url);
   if (!response.ok) throw new Error("Unable to fetch station list.");
   const data = await response.json();
+  console.log('📦 NOAA full response:', data);
   const stations = data.stations || [];
+  console.log(
+    stations.length > 0 ? '✅ Stations found' : '❌ No stations found',
+  );
   cacheService.set(key, stations, STATION_CACHE_TTL);
+  console.log('🏁 Returning stations:', stations);
   return stations;
 }
 
@@ -61,6 +66,7 @@ export async function getStationsNearCoordinates(
   console.log('⬅️ NOAA response status:', response.status);
   if (!response.ok) throw new Error('Unable to fetch station list.');
   const data = await response.json();
+  console.log('📦 NOAA full response:', data);
   const rawStations: Station[] = data.stations || [];
   console.log('📄 Raw stations returned:', rawStations.length);
   console.log(
@@ -98,6 +104,7 @@ export async function getStationsNearCoordinates(
     '🏅 Sorted station order:',
     stations.map((s) => `${s.id}:${s.name}`).join(', '),
   );
+  console.log('🏁 Returning stations:', stations);
   return stations;
 }
 


### PR DESCRIPTION
## Summary
- log full station API responses and return arrays
- log final `availableStations` array in the Index page

## Testing
- `npm run lint` *(fails: Unexpected any/require-imports)*
- `npm run test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686a889cb764832d9627dfcb92abf6bf