### PR TITLE
Fix station radius filter

### DIFF
--- a/src/services/noaaService.ts
+++ b/src/services/noaaService.ts
@@ -20,6 +20,8 @@ export async function getStationsForUserLocation(
   if (lat != null && lon != null) {
     const nearby = await getStationsNearCoordinates(lat, lon);
     if (nearby.length > 0) return nearby;
+    console.log('🔄 Falling back to name search with distance filter');
+    return getStationsForLocation(userInput, lat, lon);
   }
   return getStationsForLocation(userInput);
 }


### PR DESCRIPTION
## Summary
- filter station list by distance when falling back to name search
- support radius filtering in `getStationsForLocation`
- log raw station counts and filtered results

## Testing
- `npm run lint` *(fails: 50 problems)*

------
https://chatgpt.com/codex/tasks/task_e_686a8b949efc832d9f3124365b6ee2da