### PR TITLE
Fix zip tide data effect and logging

### DIFF
--- a/src/hooks/useTideData.tsx
+++ b/src/hooks/useTideData.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 import { isSameDay } from 'date-fns';
-import { getTideData, Prediction } from '@/services/tideDataService';
+import { getTideData, Prediction, buildNoaaUrl } from '@/services/tideDataService';
 import { fetchSixMinuteRange } from '@/services/tide/tideService';
 import { Station } from '@/services/tide/stationService';
 import {
@@ -213,8 +213,15 @@ export const useTideData = ({ location, station }: UseTideDataParams): UseTideDa
       }
     };
 
-    fetchTideDataForStation(location, station);
-  }, [location, station]);
+    // React to changes in the selected location or station
+    useEffect(() => {
+      console.log('[ZIP] Coordinates:', { lat: location?.lat, lng: location?.lng });
+      console.log('[ZIP] Station ID:', station?.id);
+      if (location?.lat != null && location?.lng != null && station) {
+        console.log('[TIDE] Fetch URL:', buildNoaaUrl(String(station.id), getCurrentIsoDateString()));
+        fetchTideDataForStation(location, station);
+      }
+    }, [location, station]);
 
   // Refetch when the station id itself changes to avoid race conditions
   useEffect(() => {

--- a/src/services/tideDataService.ts
+++ b/src/services/tideDataService.ts
@@ -6,6 +6,27 @@
 const NOAA_DATA_BASE =
   'https://api.tidesandcurrents.noaa.gov/api/prod/datagetter';
 
+export function buildNoaaUrl(stationId: string, dateIso: string): string {
+  const start = new Date(dateIso);
+  const end = new Date(start);
+  end.setDate(start.getDate() + 7);
+
+  const format = (d: Date) => d.toISOString().slice(0, 10).replace(/-/g, '');
+
+  return `${NOAA_DATA_BASE}?${new URLSearchParams({
+    product: 'predictions',
+    application: 'LunarWaveWatcher',
+    format: 'json',
+    datum: 'MLLW',
+    time_zone: 'lst_ldt',
+    interval: 'hilo',
+    units: 'english',
+    station: stationId,
+    begin_date: format(start),
+    end_date: format(end),
+  }).toString()}`;
+}
+
 export interface Prediction {
   /** ISO date-time in the station’s local time zone (e.g. “2025-06-25T04:36:00”) */
   timeIso: string;


### PR DESCRIPTION
## Summary
- add `buildNoaaUrl` helper to `tideDataService`
- call `buildNoaaUrl` and fetch tide data inside a new `useEffect`
- log coordinates, station id, and fetch URL on changes

## Testing
- `npm run build`
- `npm run lint` *(fails: many lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_686aa4140e38832d85460cebc62d1afa