### PR TITLE
Fix station loop with caching

### DIFF
--- a/src/services/stationCache.ts
+++ b/src/services/stationCache.ts
@@ -1,0 +1,47 @@
+import { safeLocalStorage } from '@/utils/localStorage';
+import { getStationsNearCoordinates, Station } from './tide/stationService';
+
+export interface Coordinates {
+  lat: number;
+  lng: number;
+}
+
+const CACHE_TTL = 60 * 60 * 1000; // 1 hour
+
+/**
+ * Caches station data with 1-hour TTL to prevent duplicate fetches
+ */
+export const getCachedStations = async (
+  coords: Coordinates,
+): Promise<Station[]> => {
+  const cacheKey = `stations-${coords.lat.toFixed(3)},${coords.lng.toFixed(3)}`;
+
+  try {
+    const cached = safeLocalStorage.get(cacheKey);
+    if (cached && cached.timestamp && Date.now() - cached.timestamp < CACHE_TTL) {
+      console.log(`[CACHE] HIT: ${cacheKey}`);
+      return cached.data as Station[];
+    }
+    if (cached) {
+      console.log(`[CACHE] EXPIRED: ${cacheKey}`);
+    } else {
+      console.log(`[CACHE] MISS: ${cacheKey}`);
+    }
+  } catch (err) {
+    console.warn('[CACHE] Read error', err);
+  }
+
+  const stations = await getStationsNearCoordinates(
+    coords.lat,
+    coords.lng,
+    30,
+  );
+  try {
+    safeLocalStorage.set(cacheKey, { timestamp: Date.now(), data: stations });
+    console.log(`[CACHE] SET: ${cacheKey}`);
+  } catch (err) {
+    console.warn('[CACHE] Write error', err);
+  }
+
+  return stations;
+};

--- a/src/services/stationFinder.ts
+++ b/src/services/stationFinder.ts
@@ -18,15 +18,19 @@ export interface NOAAStation {
  */
 export function filterStations(
   userCoords: { lat: number; lng: number },
-  stations: NOAAStation[],
+  stations: Array<NOAAStation | any>,
 ): string | null {
-  const stationsWithDistance = stations.map((s) => ({
-    ...s,
-    distance: haversineDistance(
-      userCoords,
-      { lat: Number(s.lat), lng: Number(s.lng) },
-    ),
-  }));
+  const stationsWithDistance = stations.map((s) => {
+    const lat = (s as any).lat ?? (s as any).latitude;
+    const lng = (s as any).lng ?? (s as any).longitude;
+    return {
+      ...s,
+      distance: haversineDistance(userCoords, {
+        lat: Number(lat),
+        lng: Number(lng),
+      }),
+    };
+  });
 
   console.log('[STATION] Raw stations:', stations.length);
 


### PR DESCRIPTION
## Summary
- add stationCache service for coordinate-based cache
- prevent repeated station fetches in `useTideData`
- memoize nearest station and add debug logging
- allow `filterStations` to accept Station objects
- fix dependency array to avoid rerender loop

## Testing
- `npm run lint` *(fails: 61 problems)*

------
https://chatgpt.com/codex/tasks/task_e_686aaecff548832d93fe1d8e5cca1234