### PR TITLE
Fix infinite re-render loop in Index page

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useLayoutEffect, useState, useRef } from 'react';
+import React, { useEffect, useLayoutEffect, useState, useRef, useCallback } from 'react';
 import { toast } from 'sonner';
 import AppHeader from '@/components/AppHeader';
 import MainContent from '@/components/MainContent';
@@ -44,9 +44,9 @@ const Index = () => {
     setSelectedStation(st);
   };
 
-  const handleStationsFound = (stations: Station[]) => {
+  const handleStationsFound = useCallback((stations: Station[]) => {
     setIncomingStations(stations);
-  };
+  }, []);
 
   console.log('🌊 Current location for useTideData:', currentLocation);
 


### PR DESCRIPTION
## Summary
- stabilize `handleStationsFound` in `Index.tsx` using `useCallback`

## Testing
- `npm run lint` *(fails: many pre-existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_686ae0eaedb8832da3aad63839405703