### PR TITLE
Add debug logs for input parsing and tide data

### DIFF
--- a/src/hooks/useTideData.tsx
+++ b/src/hooks/useTideData.tsx
@@ -265,6 +265,12 @@ export const useTideData = ({ location, station }: UseTideDataParams): UseTideDa
             } as TideForecast;
           });
 
+        console.log('[DEBUG] Final tide data shapes:', {
+          detailedPoints: detailedPoints.length,
+          tidePoints: tidePoints.length,
+          forecastDays: forecast.length,
+        });
+
         setTideData(curveData);
         setTideEvents(tidePoints);
         setWeeklyForecast(forecast);
@@ -275,6 +281,7 @@ export const useTideData = ({ location, station }: UseTideDataParams): UseTideDa
         setIsInland(false);
         setIsLoading(false);
       } catch (err) {
+        console.error('[DEBUG] Tide data processing error:', err);
         setError(err instanceof Error ? err.message : 'Failed to fetch tide data');
         setIsLoading(false);
         setTideData([]);

--- a/src/services/noaaService.ts
+++ b/src/services/noaaService.ts
@@ -6,6 +6,8 @@ import {
 } from './tide/stationService';
 import { Station } from './tide/stationService';
 
+const NOAA_MDAPI_BASE = 'https://api.tidesandcurrents.noaa.gov/mdapi/prod/webapi';
+
 // Always use dynamic live lookup for NOAA stations
 export async function getStationsForUserLocation(
   userInput: string,
@@ -18,11 +20,17 @@ export async function getStationsForUserLocation(
     lon,
   });
   if (lat != null && lon != null) {
+    const url = `${NOAA_MDAPI_BASE}/stations.json?type=tidepredictions&lat=${lat}&lon=${lon}&radius=30`;
+    console.log('[DEBUG] NOAA Service Request:', url);
     const nearby = await getStationsNearCoordinates(lat, lon, 30);
     if (nearby.length > 0) return nearby;
     console.log('🔄 Falling back to name search with distance filter');
+    const fallbackUrl = `${NOAA_MDAPI_BASE}/stations.json?type=tidepredictions&name=${encodeURIComponent(userInput)}`;
+    console.log('[DEBUG] NOAA Service Request:', fallbackUrl);
     return getStationsForLocation(userInput, lat, lon, 30);
   }
+  const url = `${NOAA_MDAPI_BASE}/stations.json?type=tidepredictions&name=${encodeURIComponent(userInput)}`;
+  console.log('[DEBUG] NOAA Service Request:', url);
   return getStationsForLocation(userInput);
 }
 

--- a/src/utils/locationInputParser.ts
+++ b/src/utils/locationInputParser.ts
@@ -10,49 +10,56 @@ export type ParsedInput = {
 };
 
 export const parseLocationInput = (input: string): ParsedInput | null => {
+  console.log('[DEBUG] Parser Input:', input);
   const trimmed = input.trim();
+
+  let result: ParsedInput | null = null;
 
   // NOAA station id (6-7 digits)
   if (/^\d{6,7}$/.test(trimmed)) {
-    return { type: 'stationId', stationId: trimmed };
-  }
-  
-  // ZIP code only (5 digits)
-  if (/^\d{5}$/.test(trimmed)) {
-    return { type: 'zip', zipCode: trimmed };
-  }
-  
-  // City, State ZIP (e.g., "Newport, RI 02840" OR "Newport Rhode Island 02840")
-  const cityStateZipMatch = trimmed.match(/^(.+?)(?:,\s*|\s+)([A-Za-z\s]+)\s+(\d{5})$/);
-  if (cityStateZipMatch) {
-    const state = normalizeState(cityStateZipMatch[2]);
-    if (state) {
-      return {
-        type: 'cityStateZip',
-        city: cityStateZipMatch[1].trim(),
-        state,
-        zipCode: cityStateZipMatch[3]
-      };
+    result = { type: 'stationId', stationId: trimmed };
+  } else if (/^\d{5}$/.test(trimmed)) {
+    // ZIP code only (5 digits)
+    result = { type: 'zip', zipCode: trimmed };
+  } else {
+    // City, State ZIP (e.g., "Newport, RI 02840" OR "Newport Rhode Island 02840")
+    const cityStateZipMatch = trimmed.match(/^(.+?)(?:,\s*|\s+)([A-Za-z\s]+)\s+(\d{5})$/);
+    if (cityStateZipMatch) {
+      const state = normalizeState(cityStateZipMatch[2]);
+      if (state) {
+        result = {
+          type: 'cityStateZip',
+          city: cityStateZipMatch[1].trim(),
+          state,
+          zipCode: cityStateZipMatch[3]
+        };
+      }
+    }
+
+    if (!result) {
+      // City, State (e.g., "Newport, RI" OR "Newport Rhode Island")
+      const cityStateMatch = trimmed.match(/^(.+?)(?:,\s*|\s+)([A-Za-z\s]+)$/);
+      if (cityStateMatch) {
+        const state = normalizeState(cityStateMatch[2]);
+        if (state) {
+          result = {
+            type: 'cityState',
+            city: cityStateMatch[1].trim(),
+            state
+          };
+        }
+      }
+    }
+
+    if (!result && trimmed.length > 0) {
+      // Fallback: treat as NOAA station name or free-form location text
+      result = { type: 'stationName', stationName: trimmed };
     }
   }
 
-  // City, State (e.g., "Newport, RI" OR "Newport Rhode Island")
-  const cityStateMatch = trimmed.match(/^(.+?)(?:,\s*|\s+)([A-Za-z\s]+)$/);
-  if (cityStateMatch) {
-    const state = normalizeState(cityStateMatch[2]);
-    if (state) {
-      return {
-        type: 'cityState',
-        city: cityStateMatch[1].trim(),
-        state
-      };
-    }
-  }
-
-  // Fallback: treat as NOAA station name or free-form location text
-  if (trimmed.length > 0) {
-    return { type: 'stationName', stationName: trimmed };
-  }
-
-  return null;
+  console.log('[DEBUG] Parser Output:', {
+    zipCode: result?.zipCode,
+    stationId: result?.stationId,
+  });
+  return result;
 };


### PR DESCRIPTION
## Summary
- log input and output in `parseLocationInput`
- log NOAA service request URLs in `getStationsForUserLocation`
- log tide data shapes and errors in `useTideData`

## Testing
- `npm run lint` *(fails: Unexpected any errors)*

------
https://chatgpt.com/codex/tasks/task_e_686c2d7bc690832d97efdead2100248a