### PR TITLE
Add debug logging

### DIFF
--- a/src/services/noaaService.ts
+++ b/src/services/noaaService.ts
@@ -17,7 +17,35 @@ export async function getStationsForUserLocation(
   if (lat != null && lon != null) {
     const urlNear = `https://api.tidesandcurrents.noaa.gov/mdapi/prod/webapi/stations.json?type=tidepredictions&lat=${lat}&lon=${lon}&radius=100`;
     console.log('[DEBUG] NOAA fetch URL:', urlNear);
+    const stationId = '';
+    const startDate = '';
+    const endDate = '';
+    const url = urlNear;
+    console.log('[NOAA-DEBUG] Request URL:', {
+      fullURL: url,
+      params: {
+        station: stationId,
+        begin_date: startDate,
+        end_date: endDate,
+        product: 'predictions',
+        interval: '6'
+      },
+      timestamp: new Date().toISOString()
+    });
     const nearby = await getStationsNearCoordinates(lat, lon);
+    const data = { stations: nearby };
+    const lng = lon;
+    console.log('[NOAA-DEBUG] Nearby Stations:', {
+      radius: '30km',
+      validStations: data.stations
+        .filter(s => s.type === 'T') // Only tide stations
+        .map(s => ({
+          id: s.id,
+          name: s.name,
+          distance: `${(calculateDistance(lat, lng, s.lat, s.lng)).toFixed(1)}km`,
+          active: s.id === stationId
+        }))
+    });
     console.log('[STATIONS] Nearby Stations:', {
       radius: '30km',
       count: nearby.length,

--- a/src/utils/stationUtils.ts
+++ b/src/utils/stationUtils.ts
@@ -2,12 +2,18 @@ import { Station } from '@/services/tide/stationService';
 
 type UiStation = Station & { type?: string };
 export function logStationOptions(currentStation: string | null, stations: UiStation[]): void {
-  console.log('[STATION-UI] Available Stations:', {
-    default: currentStation,
+  console.log('[STATION-DEBUG] User Options:', {
+    defaultStation: '8452660', // Newport, RI
     alternatives: stations
-      .filter((s) => s.id !== currentStation && s.type === 'T')
-      .sort((a, b) => (a.distance ?? Infinity) - (b.distance ?? Infinity))
-      .slice(0, 3), // Top 3 nearest
+      .filter(s => s.type === 'T' && s.id !== '8452660')
+      .sort((a, b) => a.distance - b.distance)
+      .slice(0, 3) // Top 3 closest
+      .map(s => ({
+        id: s.id,
+        name: s.name,
+        coords: [s.lat, s.lng]
+      })),
+    forcedSelection: true // Disable auto-picking
   });
 }
 


### PR DESCRIPTION
## Summary
- add NOAA API debug output in tide data hook
- emit request and station debug info from NOAA service
- update station-utils debug to show options

## Testing
- `npm run lint` *(fails: Unexpected any)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686c52309b6c832d92cdb2dc0c7639e4