### PR TITLE
Fix station API parameter

### DIFF
--- a/src/services/tide/stationService.ts
+++ b/src/services/tide/stationService.ts
@@ -67,7 +67,7 @@ export async function getStationById(id: string): Promise<Station | null> {
   const cached = cacheService.get<Station>(key);
   if (cached) return cached;
 
-  const url = `${NOAA_MDAPI_BASE}/stations/${id}.json`;
+  const url = `${NOAA_MDAPI_BASE}/stations/${id}.json?type=waterlevels`;
 
   const response = await fetch(url);
   if (!response.ok) throw new Error('Unable to fetch station');


### PR DESCRIPTION
## Summary
- append `type=waterlevels` when requesting a station by id

## Testing
- `npm run lint` *(fails: Unexpected any, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_686d1ca6a214832d85a067618c3b3b27