### PR TITLE
Fix station lookup network fallback

### DIFF
--- a/src/services/tide/stationService.ts
+++ b/src/services/tide/stationService.ts
@@ -70,6 +70,7 @@ export async function getStationById(id: string): Promise<Station | null> {
   const url = ${NOAA_MDAPI_BASE}/stations/${id}.json;
 
   const response = await fetch(url);
+  if (response.status === 404) return null;
   if (!response.ok) throw new Error('Unable to fetch station');
   const data = await response.json();
   if (!data.station) return null;


### PR DESCRIPTION
## Summary
- handle 404 response in `getStationById`

## Testing
- `npm run lint` *(fails: Unexpected any)*

------
https://chatgpt.com/codex/tasks/task_e_686d7b58a150832daa6a7e04df0519e8