### PR TITLE
Add station object debug log

### DIFF
--- a/src/services/tide/stationService.ts
+++ b/src/services/tide/stationService.ts
@@ -84,6 +84,7 @@ export async function getStationById(id: string): Promise<Station | null> {
   if (response.status === 404) return null;
   if (!response.ok) throw new Error('Unable to fetch station');
   const data = await response.json();
+  console.log('Fetched station object:', data.station);
   if (!data.station) return null;
   const station: Station = {
     id: data.station.id,


### PR DESCRIPTION
## Summary
- log the full station object right after fetching a NOAA station by ID

## Testing
- `npm run lint`
- `node fetch-station.js` *(fails: ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_686db39c93fc832da5a8354a43c314e8