### PR TITLE
Fix station ID selection logic

### DIFF
--- a/src/hooks/useLocationSearch.tsx
+++ b/src/hooks/useLocationSearch.tsx
@@ -49,15 +49,9 @@ export const useLocationSearch = ({ onLocationSelect, onStationSelect, onClose }
         debugLog('Station lookup result', station);
         if (station) {
           onStationSelect?.(station);
-          location = {
-            zipCode: '',
-            city: station.name,
-            state: station.state || '',
-            lat: station.latitude,
-            lng: station.longitude,
-            isManual: false,
-            timestamp: Date.now(),
-          };
+          toast.success(`Using station ${station.name}`);
+          onClose?.();
+          return; // station handler sets current location
         }
       } else if (parsed.type === 'stationName') {
         location = {


### PR DESCRIPTION
## Summary
- avoid clearing selected station when using a NOAA station ID
- if input is a station ID, call `onStationSelect` only and skip the location change

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686dc6ac5070832db978d6fc2e574965