### PR TITLE
Handle storing selected station as current location

### DIFF
--- a/src/hooks/useLocationState.tsx
+++ b/src/hooks/useLocationState.tsx
@@ -48,6 +48,9 @@ export const useLocationState = () => {
   const setSelectedStationWithPersist = useCallback((station: Station | null) => {
     setSelectedStation(station);
     if (station) {
+      console.log('Station selected:', station.id, station.name);
+    }
+    if (station) {
       // Merge the selected station into the previous location so we retain ZIP/city info.
       const mergedLocation = {
         ...(currentLocation ?? {

--- a/src/utils/currentLocation.ts
+++ b/src/utils/currentLocation.ts
@@ -3,12 +3,34 @@ import { LocationData } from '@/types/locationTypes';
 import { safeLocalStorage } from './localStorage';
 import { locationStorage } from './locationStorage';
 
-const CURRENT_LOCATION_KEY = 'moontide-current-location';
+const CURRENT_LOCATION_KEY = 'currentLocation';
 
 export function persistCurrentLocation(location: SavedLocation & { id: string; country: string }) {
-  safeLocalStorage.set(CURRENT_LOCATION_KEY, location);
-
   const [city, state] = location.cityState.split(', ');
+  const storageObj = location.zipCode
+    ? {
+        zipCode: location.zipCode,
+        city: city || location.name,
+        state: state || '',
+        lat: location.lat,
+        lng: location.lng,
+        sourceType: 'zip' as const,
+      }
+    : {
+        stationId: location.id,
+        stationName: location.name,
+        state: state || '',
+        lat: location.lat,
+        lng: location.lng,
+        zipCode: location.zipCode || '',
+        city: city || '',
+        sourceType: 'station' as const,
+      };
+
+  console.log('Saving current location to storage:', storageObj);
+  safeLocalStorage.set(CURRENT_LOCATION_KEY, storageObj);
+  console.log('Station currentLocation saved successfully.');
+
   const locationData: LocationData = {
     zipCode: location.zipCode,
     city: city || location.name,
@@ -22,6 +44,31 @@ export function persistCurrentLocation(location: SavedLocation & { id: string; c
 }
 
 export function loadCurrentLocation(): (SavedLocation & { id: string; country: string }) | null {
+  const saved = safeLocalStorage.get(CURRENT_LOCATION_KEY);
+  console.log('Loaded currentLocation from storage:', saved);
+  if (saved) {
+    if (saved.sourceType === 'station') {
+      return {
+        id: saved.stationId,
+        name: saved.stationName,
+        country: 'USA',
+        zipCode: saved.zipCode || '',
+        cityState: `${saved.city ?? ''}, ${saved.state ?? ''}`,
+        lat: saved.lat ?? null,
+        lng: saved.lng ?? null,
+      };
+    }
+    return {
+      id: saved.zipCode || `${saved.city}-${saved.state}`,
+      name: saved.city,
+      country: 'USA',
+      zipCode: saved.zipCode || '',
+      cityState: `${saved.city}, ${saved.state}`,
+      lat: saved.lat ?? null,
+      lng: saved.lng ?? null,
+    };
+  }
+
   const stored = locationStorage.getCurrentLocation();
   if (stored) {
     return {
@@ -35,14 +82,6 @@ export function loadCurrentLocation(): (SavedLocation & { id: string; country: s
     };
   }
 
-  const saved = safeLocalStorage.get(CURRENT_LOCATION_KEY);
-  if (saved) {
-    return {
-      ...saved,
-      id: saved.id || saved.zipCode || `${saved.cityState}`,
-      country: saved.country || 'USA',
-    };
-  }
   return null;
 }
 


### PR DESCRIPTION
## Summary
- store current location info for stations under `currentLocation` in localStorage
- log station selection and storage actions

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686e68ad9f7c832d913fc68882f0cb42