### PR TITLE
Fix NOAA station extraction and add debug log

### DIFF
--- a/src/services/tide/stationService.ts
+++ b/src/services/tide/stationService.ts
@@ -93,14 +93,18 @@ export async function getStationById(id: string): Promise<Station | null> {
       throw jsonError;
     }
     if (!response.ok) throw new Error('Unable to fetch station');
-    console.log('Fetched station object:', data.station);
-    if (!data.station) return null;
+    const stationData = Array.isArray(data.stations) ? data.stations[0] : null;
+    if (!stationData) {
+      console.error('❌ No station found for this ID');
+      return null;
+    }
+    console.log('Fetched station object:', stationData);
     const station: Station = {
-      id: data.station.id,
-      name: data.station.name,
-      latitude: data.station.latitude,
-      longitude: data.station.longitude,
-      state: data.station.state,
+      id: stationData.id,
+      name: stationData.name,
+      latitude: parseFloat(stationData.lat ?? stationData.latitude),
+      longitude: parseFloat(stationData.lng ?? stationData.longitude),
+      state: stationData.state,
     };
     debugLog('Station fetched', station);
     cacheService.set(key, station, STATION_CACHE_TTL);

--- a/src/utils/currentLocation.ts
+++ b/src/utils/currentLocation.ts
@@ -7,11 +7,12 @@ import type { Station } from '@/services/tide/stationService';
 const CURRENT_LOCATION_KEY = 'currentLocation';
 
 export function persistStationCurrentLocation(station?: Station | null) {
-  console.log('Fetched station object:', station);
   if (!station) {
     console.error('Station object is undefined, not saving.');
     return;
   }
+  const stationObject = station;
+  console.log('💾 Saving fetched station object:', stationObject);
   console.log('Saving station currentLocation to storage:', station);
   const storageObj = {
     stationId: station.id,


### PR DESCRIPTION
## Summary
- parse station details from `stations[0]` when fetching by ID
- add error log when no station is returned
- log fetched station object before saving current location

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686e7af7fecc832da7d226a439aab971