### PR TITLE
Implement canonical station search & history

### DIFF
--- a/src/types/locationHistory.ts
+++ b/src/types/locationHistory.ts
@@ -1,0 +1,13 @@
+export interface LocationHistoryEntry {
+  stationId: string;
+  stationName: string;
+  nickname?: string;
+  lat: number;
+  lng: number;
+  city?: string;
+  state?: string;
+  zipCode?: string;
+  sourceType: 'zip' | 'text' | 'gps' | 'station';
+  searchQuery?: string;
+  timestamp: number;
+}

--- a/src/utils/currentLocation.ts
+++ b/src/utils/currentLocation.ts
@@ -2,7 +2,9 @@ import { SavedLocation } from '@/components/LocationSelector';
 import { LocationData } from '@/types/locationTypes';
 import { safeLocalStorage } from './localStorage';
 import { locationStorage } from './locationStorage';
+import { addLocationHistory } from './locationHistory';
 import type { Station } from '@/services/tide/stationService';
+import type { LocationHistoryEntry } from '@/types/locationHistory';
 
 const CURRENT_LOCATION_KEY = 'currentLocation';
 
@@ -37,6 +39,20 @@ export function persistStationCurrentLocation(station?: Station | null) {
     nickname: undefined,
   };
   locationStorage.saveCurrentLocation(locationData);
+
+  const entry: LocationHistoryEntry = {
+    stationId: station.id,
+    stationName: station.name,
+    nickname: undefined,
+    lat: station.latitude,
+    lng: station.longitude,
+    city: station.city ?? '',
+    state: station.state ?? '',
+    zipCode: station.zip ?? '',
+    sourceType: 'station',
+    timestamp: Date.now(),
+  };
+  addLocationHistory(entry);
 }
 
 export function persistCurrentLocation(location: SavedLocation & { id: string; country: string }) {
@@ -75,6 +91,20 @@ export function persistCurrentLocation(location: SavedLocation & { id: string; c
     nickname: location.name !== city ? location.name : undefined,
   };
   locationStorage.saveCurrentLocation(locationData);
+
+  const entry: LocationHistoryEntry = {
+    stationId: storageObj.stationId ?? location.id,
+    stationName: storageObj.stationName ?? location.name,
+    nickname: location.name !== city ? location.name : undefined,
+    lat: location.lat,
+    lng: location.lng,
+    city: city || undefined,
+    state: state || undefined,
+    zipCode: location.zipCode || undefined,
+    sourceType: storageObj.sourceType,
+    timestamp: Date.now(),
+  };
+  addLocationHistory(entry);
 }
 
 export function loadCurrentLocation(): (SavedLocation & { id: string; country: string }) | null {

--- a/src/utils/locationHistory.ts
+++ b/src/utils/locationHistory.ts
@@ -1,0 +1,14 @@
+import { safeLocalStorage } from './localStorage';
+import { LocationHistoryEntry } from '@/types/locationHistory';
+
+const HISTORY_KEY = 'station-history';
+
+export function getLocationHistory(): LocationHistoryEntry[] {
+  return safeLocalStorage.get<LocationHistoryEntry[]>(HISTORY_KEY) ?? [];
+}
+
+export function addLocationHistory(entry: LocationHistoryEntry): void {
+  const history = getLocationHistory();
+  const filtered = history.filter((h) => h.stationId !== entry.stationId);
+  safeLocalStorage.set(HISTORY_KEY, [entry, ...filtered].slice(0, 20));
+}

--- a/src/utils/stationSearch.ts
+++ b/src/utils/stationSearch.ts
@@ -1,0 +1,35 @@
+import { getDistanceKm } from '@/services/tide/geo';
+
+export type SourceType = 'zip' | 'text' | 'gps' | 'station';
+
+export interface StationCandidate {
+  stationId: string;
+  stationName: string;
+  lat: number;
+  lon: number;
+  city?: string;
+  state?: string;
+  nickname?: string;
+  zipCode?: string;
+}
+
+export interface NearbyStation extends StationCandidate {
+  distanceKm: number;
+  sourceType: SourceType;
+}
+
+export function findNearbyStations(
+  stations: StationCandidate[],
+  searchLat: number,
+  searchLon: number,
+  sourceType: SourceType,
+): NearbyStation[] {
+  return stations
+    .map((s) => ({
+      ...s,
+      distanceKm: getDistanceKm(searchLat, searchLon, s.lat, s.lon),
+      sourceType,
+    }))
+    .filter((s) => s.distanceKm <= 30)
+    .sort((a, b) => a.distanceKm - b.distanceKm);
+}


### PR DESCRIPTION
## Summary
- add `LocationHistoryEntry` type
- add utilities for station search and canonical history storage
- record canonical history entries when persisting locations

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686e873388e0832d8729e2a8f64c231f