### PR TITLE
Extend location data with station fields

### DIFF
--- a/src/hooks/useGPSLocation.tsx
+++ b/src/hooks/useGPSLocation.tsx
@@ -29,6 +29,8 @@ export const useGPSLocation = ({ onLocationSelect, onClose }: UseGPSLocationProp
             state: 'Current',
             lat: latitude,
             lng: longitude,
+            stationId: undefined,
+            stationName: undefined,
             isManual: false,
             timestamp: Date.now()
           };

--- a/src/hooks/useLocationSearch.tsx
+++ b/src/hooks/useLocationSearch.tsx
@@ -64,6 +64,8 @@ export const useLocationSearch = ({ onLocationSelect, onStationSelect, onClose }
           state: '',
           lat: null,
           lng: null,
+          stationId: undefined,
+          stationName: parsed.stationName!,
           isManual: true,
           timestamp: Date.now(),
         };
@@ -101,6 +103,8 @@ export const useLocationSearch = ({ onLocationSelect, onStationSelect, onClose }
         state: stateAbbr,
         lat: parseFloat(place.latitude),
         lng: parseFloat(place.longitude),
+        stationId: undefined,
+        stationName: undefined,
         isManual: false,
         timestamp: Date.now()
       };
@@ -121,6 +125,8 @@ export const useLocationSearch = ({ onLocationSelect, onStationSelect, onClose }
         state: parsed.state!,
         lat: parseFloat(place.latitude),
         lng: parseFloat(place.longitude),
+        stationId: undefined,
+        stationName: undefined,
         isManual: false,
         timestamp: Date.now()
       };
@@ -141,6 +147,8 @@ export const useLocationSearch = ({ onLocationSelect, onStationSelect, onClose }
         state: parsed.state!,
         lat: geocodeResult.lat,
         lng: geocodeResult.lng,
+        stationId: undefined,
+        stationName: undefined,
         isManual: false,
         timestamp: Date.now()
       };
@@ -155,6 +163,8 @@ export const useLocationSearch = ({ onLocationSelect, onStationSelect, onClose }
         state: parsed.state!,
         lat: null,
         lng: null,
+        stationId: undefined,
+        stationName: undefined,
         isManual: true,
         timestamp: Date.now()
       };

--- a/src/types/locationTypes.ts
+++ b/src/types/locationTypes.ts
@@ -5,6 +5,8 @@ export interface LocationData {
   state: string;
   lat: number | null;
   lng: number | null;
+  stationId?: string;
+  stationName?: string;
   isManual: boolean;
   timestamp?: number; // When this location was saved
   nickname?: string; // User-defined nickname for the location


### PR DESCRIPTION
## Summary
- include `stationId` and `stationName` in `LocationData`
- persist station details in current location helpers
- propagate new fields in location search and GPS hooks

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686eaabd249c832dad45fd16732031f9