### PR TITLE
Refactor header to sticky two-line banner

### DIFF
--- a/src/components/AppHeader.tsx
+++ b/src/components/AppHeader.tsx
@@ -1,67 +1,51 @@
 
 import React from 'react';
 import { Link } from 'react-router-dom';
-import { CloudMoon, Calendar, Settings } from "lucide-react";
+import { CloudMoon, Calendar, Settings, MapPin } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import LocationSelector, { SavedLocation } from './LocationSelector';
 import { Station } from '@/services/tide/stationService';
 
 interface AppHeaderProps {
-  currentLocation: SavedLocation & { id: string; country: string } | null;
-  stationName: string | null;
   onLocationChange: (location: SavedLocation) => void;
   onStationSelect?: (station: Station) => void;
-  onLocationClear?: () => void;
-  hasError?: boolean;
   forceShowLocationSelector?: boolean;
   onLocationSelectorClose?: () => void;
 }
 
 export default function AppHeader({
-  currentLocation,
-  stationName,
   onLocationChange,
   onStationSelect,
-  onLocationClear,
-  hasError,
   forceShowLocationSelector,
   onLocationSelectorClose
 }: AppHeaderProps) {
   return (
-    <header className="py-4 px-4 sm:px-6 lg:px-8">
-      <div className="container mx-auto">
-        <div className="flex flex-wrap items-center justify-between gap-y-2">
-          <div className="flex items-center w-full justify-center sm:w-auto sm:justify-start">
-            <CloudMoon className="h-8 w-8 text-moon-primary mr-2" />
-            <h1 className="text-2xl font-bold bg-gradient-to-r from-moon-primary to-moon-blue bg-clip-text text-transparent">
-              MoonTide
-            </h1>
-            {stationName && (
-              <span className="ml-2 text-sm text-muted-foreground hidden md:inline">
-                {stationName}
-              </span>
-            )}
-          </div>
-          <div className="flex items-center gap-2 flex-wrap w-full justify-center sm:w-auto sm:justify-end">
-            <Link to="/fishing-calendar">
-              <Button variant="outline" className="flex items-center gap-1">
-                <Calendar className="h-4 w-4" />
-                <span className="hidden md:inline">Calendar</span>
-              </Button>
-            </Link>
-            <Link to="/settings">
-              <Button variant="outline" className="flex items-center gap-1">
-                <Settings className="h-4 w-4" />
-                <span className="hidden md:inline">Settings</span>
-              </Button>
-            </Link>
-            <LocationSelector
-              onSelect={onLocationChange}
-              onStationSelect={onStationSelect}
-              forceOpen={forceShowLocationSelector}
-              onClose={onLocationSelectorClose}
-            />
-          </div>
+    <header className="fixed top-0 left-0 right-0 z-50 bg-background/90 backdrop-blur-sm shadow-md">
+      <div className="flex flex-col w-full">
+        <div className="flex items-center justify-center py-2">
+          <CloudMoon className="h-6 w-6 text-moon-primary mr-2" />
+          <h1 className="text-xl font-bold bg-gradient-to-r from-moon-primary to-moon-blue bg-clip-text text-transparent">
+            MoonTide
+          </h1>
+        </div>
+        <div className="flex items-center justify-evenly py-2 w-full">
+          <Link to="/fishing-calendar">
+            <Button variant="ghost" size="icon">
+              <Calendar className="h-5 w-5" />
+            </Button>
+          </Link>
+          <Link to="/settings">
+            <Button variant="ghost" size="icon">
+              <Settings className="h-5 w-5" />
+            </Button>
+          </Link>
+          <LocationSelector
+            onSelect={onLocationChange}
+            onStationSelect={onStationSelect}
+            forceOpen={forceShowLocationSelector}
+            onClose={onLocationSelectorClose}
+            triggerContent={<MapPin className="h-5 w-5" />}
+          />
         </div>
       </div>
     </header>

--- a/src/components/LocationSelector.tsx
+++ b/src/components/LocationSelector.tsx
@@ -25,13 +25,15 @@ export default function LocationSelector({
   onLocationClear,
   forceOpen,
   onClose,
-  onStationSelect
+  onStationSelect,
+  triggerContent
 }: {
   onSelect: (loc: SavedLocation) => void;
   onLocationClear?: () => void;
   forceOpen?: boolean;
   onClose?: () => void;
   onStationSelect?: (station: Station) => void;
+  triggerContent?: React.ReactNode;
 }) {
   const [isOpen, setIsOpen] = useState(false);
   const [showAddNew, setShowAddNew] = useState(false);
@@ -108,8 +110,12 @@ export default function LocationSelector({
     <DropdownMenu open={isOpen} onOpenChange={handleOpenChange}>
       <DropdownMenuTrigger asChild>
         <button className="flex items-center gap-1 px-3 py-2 text-sm font-medium">
-          <MapPin size={16} />
-          Change
+          {triggerContent ?? (
+            <>
+              <MapPin size={16} />
+              Change
+            </>
+          )}
         </button>
       </DropdownMenuTrigger>
 

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -151,18 +151,14 @@ const Index = () => {
   });
 
   return (
-    <div className="min-h-screen pb-8 relative">
+    <div className="min-h-screen pb-8 pt-24 relative">
       <StarsBackdrop />
       <LoadingOverlay show={isStationLoading} message="Finding tide stations..." />
       <LoadingOverlay show={isLoading} message="Fetching tide data..." />
       
       <AppHeader
-        currentLocation={currentLocation}
-        stationName={stationName}
         onLocationChange={handleLocationChange}
         onStationSelect={handleStationSelect}
-        onLocationClear={handleLocationClear}
-        hasError={!!error}
         forceShowLocationSelector={showLocationSelector}
         onLocationSelectorClose={() => setShowLocationSelector(false)}
       />


### PR DESCRIPTION
## Summary
- implement sticky banner layout in `AppHeader`
- add icon-only trigger option to `LocationSelector`
- apply top padding in main page for banner

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686ec18dce90832d8e816aaed9ef0c6a