### PR TITLE
Hide location button after location loaded

### DIFF
--- a/src/components/MainContent.tsx
+++ b/src/components/MainContent.tsx
@@ -42,6 +42,8 @@ export default function MainContent({
     date: formatApiDate(currentDate)
   };
 
+  const hasData = tideData.length > 0 || weeklyForecast.length > 0;
+
   return (
     <main className="container mx-auto px-4 sm:px-6 lg:px-8 pt-4">
       <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
@@ -56,6 +58,7 @@ export default function MainContent({
           stationId={stationId}
           error={error}
           onGetStarted={onGetStarted}
+          hasData={hasData}
         />
 
         <TideChart

--- a/src/components/MoonPhase.tsx
+++ b/src/components/MoonPhase.tsx
@@ -24,6 +24,7 @@ type MoonPhaseProps = {
   stationId?: string | null;
   error?: string | null;
   onGetStarted?: (location?: LocationData) => void;
+  hasData?: boolean;
 }
 
 const MoonPhase = ({
@@ -37,10 +38,18 @@ const MoonPhase = ({
   stationName,
   stationId,
   error,
-  onGetStarted
+  onGetStarted,
+  hasData
 }: MoonPhaseProps) => {
   // Simplified location detection - just check if location exists and has basic data
-  const hasLocation = Boolean(currentLocation && (currentLocation.zipCode || currentLocation.cityState));
+  const hasLocation = Boolean(
+    currentLocation &&
+    (
+      currentLocation.zipCode ||
+      currentLocation.cityState ||
+      (typeof currentLocation.lat === 'number' && typeof currentLocation.lng === 'number')
+    )
+  );
 
   console.log('🌙 MoonPhase - Location check:', {
     hasCurrentLocation: !!currentLocation,
@@ -105,7 +114,11 @@ const MoonPhase = ({
                 error={error}
               />
             ) : (
-              <OnboardingInfo onGetStarted={onGetStarted || (() => {})} />
+              <OnboardingInfo
+                onGetStarted={onGetStarted || (() => {})}
+                currentLocation={currentLocation}
+                hasData={hasData}
+              />
             )}
           </div>
         </CardContent>

--- a/src/components/OnboardingInfo.tsx
+++ b/src/components/OnboardingInfo.tsx
@@ -6,12 +6,15 @@ import { Info, Search, X } from 'lucide-react';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from '@/components/ui/dialog';
 import UnifiedLocationInput from './UnifiedLocationInput';
 import { LocationData } from '@/types/locationTypes';
+import { SavedLocation } from './LocationSelector';
 
 type OnboardingInfoProps = {
   onGetStarted: (location?: LocationData) => void;
+  currentLocation?: (SavedLocation & { id: string; country: string }) | null;
+  hasData?: boolean;
 };
 
-const OnboardingInfo = ({ onGetStarted }: OnboardingInfoProps) => {
+const OnboardingInfo = ({ onGetStarted, currentLocation, hasData }: OnboardingInfoProps) => {
   const [showLocationModal, setShowLocationModal] = useState(false);
   const [nickname, setNickname] = useState('');
 
@@ -37,6 +40,10 @@ const OnboardingInfo = ({ onGetStarted }: OnboardingInfoProps) => {
   const handleModalClose = () => {
     setShowLocationModal(false);
   };
+
+  if (currentLocation && hasData) {
+    return null;
+  }
 
   return (
     <>


### PR DESCRIPTION
## Summary
- hide `Enter Your Location` button once location + data exist
- expose `hasData` through `MainContent` and `MoonPhase`
- improve location detection when lat/lng available

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686ec4e58de4832db49ac921ee6127f9