### PR TITLE
Remove redundant location info

### DIFF
--- a/src/components/MainContent.tsx
+++ b/src/components/MainContent.tsx
@@ -54,9 +54,6 @@ export default function MainContent({
           moonset={moonPhaseData.moonset}
           date={moonPhaseData.date}
           currentLocation={currentLocation}
-          stationName={stationName}
-          stationId={stationId}
-          error={error}
           onGetStarted={onGetStarted}
           hasData={hasData}
         />

--- a/src/components/MoonPhase.tsx
+++ b/src/components/MoonPhase.tsx
@@ -8,7 +8,6 @@ import MoonVisual from './MoonVisual';
 import MoonData from './MoonData';
 import SolarInfo from './SolarInfo';
 import OnboardingInfo from './OnboardingInfo';
-import LocationInfo from './LocationInfo';
 import { LocationData } from '@/types/locationTypes';
 import { SavedLocation } from './LocationSelector';
 
@@ -20,9 +19,6 @@ type MoonPhaseProps = {
   date: string;
   className?: string;
   currentLocation?: (SavedLocation & { id: string; country: string }) | null;
-  stationName?: string | null;
-  stationId?: string | null;
-  error?: string | null;
   onGetStarted?: (location?: LocationData) => void;
   hasData?: boolean;
 }
@@ -35,9 +31,6 @@ const MoonPhase = ({
   date,
   className,
   currentLocation,
-  stationName,
-  stationId,
-  error,
   onGetStarted,
   hasData
 }: MoonPhaseProps) => {
@@ -106,14 +99,7 @@ const MoonPhase = ({
           <div className="border-t border-muted pt-4 w-full space-y-4">
             <SolarInfo solarTimes={solarTimes} />
 
-            {hasLocation ? (
-              <LocationInfo
-                currentLocation={currentLocation}
-                stationName={stationName}
-                stationId={stationId}
-                error={error}
-              />
-            ) : (
+            {!hasLocation && (
               <OnboardingInfo
                 onGetStarted={onGetStarted || (() => {})}
                 currentLocation={currentLocation}


### PR DESCRIPTION
## Summary
- simplify `MoonPhase` props and remove `LocationInfo`
- stop rendering duplicate location details in the MoonPhase card
- adjust `MainContent` usage

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686ec96221d8832db0ae832026f373c7