### PR TITLE
Move MA map test button to header

### DIFF
--- a/src/components/AppHeader.tsx
+++ b/src/components/AppHeader.tsx
@@ -22,11 +22,16 @@ export default function AppHeader({
   return (
     <header className="fixed top-0 left-0 right-0 z-50 bg-background/90 backdrop-blur-sm shadow-md">
       <div className="flex flex-col w-full">
-        <div className="flex items-center justify-center py-2">
-          <CloudMoon className="h-6 w-6 text-moon-primary mr-2" />
-          <h1 className="text-xl font-bold bg-gradient-to-r from-moon-primary to-moon-blue bg-clip-text text-transparent">
-            MoonTide
-          </h1>
+        <div className="flex items-center justify-between py-2 px-4">
+          <div className="flex items-center">
+            <CloudMoon className="h-6 w-6 text-moon-primary mr-2" />
+            <h1 className="text-xl font-bold bg-gradient-to-r from-moon-primary to-moon-blue bg-clip-text text-transparent">
+              MoonTide
+            </h1>
+          </div>
+          <Link to="/ma-station-map-test">
+            <Button variant="outline" size="sm">Test MA Stations</Button>
+          </Link>
         </div>
         <div className="flex items-center justify-evenly py-2 w-full">
           <Link to="/fishing-calendar">

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -12,8 +12,6 @@ import StationPicker from '@/components/StationPicker';
 import { getStationsForLocationInput } from '@/services/locationService';
 import { Station, sortStationsForDefault } from '@/services/tide/stationService';
 import { filterStationsNearby } from '@/utils/stationSearch';
-import { Link } from 'react-router-dom';
-import { Button } from '@/components/ui/button';
 
 const Index = () => {
   console.log('🚀 Index component rendering...');
@@ -186,11 +184,6 @@ const Index = () => {
         currentStationId={selectedStation?.id || null}
         onClose={() => setShowStationPicker(false)}
       />
-
-      {/* Temporary button for MA station map testing */}
-      <Link to="/ma-station-map-test" className="absolute bottom-4 right-4 z-20">
-        <Button variant="outline">Test MA Stations</Button>
-      </Link>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- relocate the MA station test button from the bottom corner
- place it next to the title in `AppHeader`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686edab9acc0832d8253c8f1f24183ed