### PR TITLE
Add location onboarding screen

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import Index from "./pages/Index";
 import FishingCalendar from "./pages/FishingCalendar";
 import Settings from "./pages/Settings";
 import MassachusettsStationMapTest from "./pages/MassachusettsStationMapTest";
+import LocationOnboardingStep1 from "./pages/LocationOnboardingStep1";
 import NotFound from "./pages/NotFound";
 
 const queryClient = new QueryClient();
@@ -22,8 +23,9 @@ const App = () => (
           <Route path="/" element={<Index />} />
           <Route path="/fishing-calendar" element={<FishingCalendar />} />
           <Route path="/settings" element={<Settings />} />
-          <Route path="/ma-station-map-test" element={<MassachusettsStationMapTest />} />
-          {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
+        <Route path="/ma-station-map-test" element={<MassachusettsStationMapTest />} />
+        <Route path="/location-onboarding-step1" element={<LocationOnboardingStep1 />} />
+        {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
           <Route path="*" element={<NotFound />} />
         </Routes>
       </BrowserRouter>

--- a/src/components/AppHeader.tsx
+++ b/src/components/AppHeader.tsx
@@ -29,9 +29,14 @@ export default function AppHeader({
               MoonTide
             </h1>
           </div>
-          <Link to="/ma-station-map-test">
-            <Button variant="outline" size="sm">Test MA Stations</Button>
-          </Link>
+          <div className="flex gap-2">
+            <Link to="/ma-station-map-test">
+              <Button variant="outline" size="sm">Test MA Stations</Button>
+            </Link>
+            <Link to="/location-onboarding-step1">
+              <Button variant="outline" size="sm">Test Onboarding</Button>
+            </Link>
+          </div>
         </div>
         <div className="flex items-center justify-evenly py-2 w-full">
           <Link to="/fishing-calendar">

--- a/src/pages/LocationOnboardingStep1.tsx
+++ b/src/pages/LocationOnboardingStep1.tsx
@@ -1,0 +1,75 @@
+import React, { useState } from 'react';
+import StarsBackdrop from '@/components/StarsBackdrop';
+import { Button } from '@/components/ui/button';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+
+const states = [
+  { value: 'CA', label: 'California' },
+  { value: 'NY', label: 'New York' },
+  { value: 'TX', label: 'Texas' },
+];
+
+const citiesByState: Record<string, string[]> = {
+  CA: ['Los Angeles', 'San Francisco', 'San Diego', 'Sacramento'],
+  NY: ['New York City', 'Buffalo', 'Rochester'],
+  TX: ['Houston', 'Austin', 'Dallas', 'San Antonio'],
+};
+
+const LocationOnboardingStep1 = () => {
+  const [selectedState, setSelectedState] = useState('');
+  const [selectedCity, setSelectedCity] = useState('');
+
+  const handleStateChange = (value: string) => {
+    setSelectedState(value);
+    setSelectedCity('');
+  };
+
+  const cityOptions = selectedState ? citiesByState[selectedState] || [] : [];
+
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center relative p-4">
+      <StarsBackdrop />
+      <div className="space-y-4 w-full max-w-sm relative z-10">
+        <h1 className="text-center text-xl font-bold">Select Your Location</h1>
+
+        <Select onValueChange={handleStateChange} value={selectedState}>
+          <SelectTrigger>
+            <SelectValue placeholder="Select a state" />
+          </SelectTrigger>
+          <SelectContent>
+            {states.map((st) => (
+              <SelectItem key={st.value} value={st.value}>
+                {st.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+
+        {selectedState && (
+          <Select onValueChange={setSelectedCity} value={selectedCity}>
+            <SelectTrigger>
+              <SelectValue placeholder="Select a city" />
+            </SelectTrigger>
+            <SelectContent>
+              {cityOptions.map((city) => (
+                <SelectItem key={city} value={city}>
+                  {city}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        )}
+
+        <Button disabled={!selectedState || !selectedCity}>Next</Button>
+      </div>
+    </div>
+  );
+};
+
+export default LocationOnboardingStep1;


### PR DESCRIPTION
## Summary
- create LocationOnboardingStep1 with mock state and city dropdowns
- link onboarding test from header
- add route for onboarding page

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686ee72dd078832da2fec9b9c240df17