### PR TITLE
Switch to new onboarding screen

### DIFF
--- a/src/components/MoonPhase.tsx
+++ b/src/components/MoonPhase.tsx
@@ -7,7 +7,6 @@ import FullMoonBanner from './FullMoonBanner';
 import MoonVisual from './MoonVisual';
 import MoonData from './MoonData';
 import SolarInfo from './SolarInfo';
-import OnboardingInfo from './OnboardingInfo';
 import { LocationData } from '@/types/locationTypes';
 import { SavedLocation } from './LocationSelector';
 
@@ -98,14 +97,6 @@ const MoonPhase = ({
 
           <div className="border-t border-muted pt-4 w-full space-y-4">
             <SolarInfo solarTimes={solarTimes} />
-
-            {!hasLocation && (
-              <OnboardingInfo
-                onGetStarted={onGetStarted || (() => {})}
-                currentLocation={currentLocation}
-                hasData={hasData}
-              />
-            )}
           </div>
         </CardContent>
       </Card>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -3,6 +3,7 @@ import React, { useEffect, useLayoutEffect, useState, useRef } from 'react';
 import { toast } from 'sonner';
 import AppHeader from '@/components/AppHeader';
 import MainContent from '@/components/MainContent';
+import LocationOnboardingStep1 from './LocationOnboardingStep1';
 import StarsBackdrop from '@/components/StarsBackdrop';
 import LoadingOverlay from '@/components/LoadingOverlay';
 import { useTideData } from '@/hooks/useTideData';
@@ -149,6 +150,10 @@ const Index = () => {
     tideDataLength: tideData?.length || 0,
     hasCurrentLocation: !!currentLocation
   });
+
+  if (!currentLocation) {
+    return <LocationOnboardingStep1 />;
+  }
 
   return (
     <div className="min-h-screen pb-8 pt-24 relative">


### PR DESCRIPTION
## Summary
- remove display of old `OnboardingInfo`
- show `LocationOnboardingStep1` when user has no saved location

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686ef72024d8832d8bf6300ab66c3d80