### PR TITLE
Update NOAA station fetch limit

### DIFF
--- a/src/pages/LocationOnboardingStep1.tsx
+++ b/src/pages/LocationOnboardingStep1.tsx
@@ -52,7 +52,7 @@ const LocationOnboardingStep1 = () => {
       setError(null);
       try {
         const res = await fetch(
-          'https://api.tidesandcurrents.noaa.gov/mdapi/prod/webapi/stations.json?rows=200'
+          'https://api.tidesandcurrents.noaa.gov/mdapi/prod/webapi/stations.json?rows=10000'
         );
         if (!res.ok) {
           throw new Error('Failed to fetch station list');

--- a/src/pages/MassachusettsStationMapTest.tsx
+++ b/src/pages/MassachusettsStationMapTest.tsx
@@ -27,7 +27,7 @@ const MassachusettsStationMapTest = () => {
     const fetchStations = async () => {
       try {
         const response = await fetch(
-          'https://api.tidesandcurrents.noaa.gov/mdapi/prod/webapi/stations.json?rows=200',
+          'https://api.tidesandcurrents.noaa.gov/mdapi/prod/webapi/stations.json?rows=10000',
         );
         if (!response.ok) throw new Error('Failed to fetch stations');
         const data = await response.json();

--- a/src/services/tide/realStationService.ts
+++ b/src/services/tide/realStationService.ts
@@ -8,7 +8,7 @@ interface NoaaStationMetadata {
   state?: string;
 }
 
-const NOAA_STATIONS_API = 'https://api.tidesandcurrents.noaa.gov/mdapi/prod/webapi/stations.json?rows=200';
+const NOAA_STATIONS_API = 'https://api.tidesandcurrents.noaa.gov/mdapi/prod/webapi/stations.json?rows=10000';
 
 let stationCache: NoaaStationMetadata[] | null = null;
 

--- a/src/services/tide/stationService.ts
+++ b/src/services/tide/stationService.ts
@@ -31,7 +31,7 @@ export async function getStationsForLocation(
     return cached;
   }
 
-  const url = `${NOAA_MDAPI_BASE}/stations.json?type=tidepredictions&rows=200&name=${encodeURIComponent(
+  const url = `${NOAA_MDAPI_BASE}/stations.json?type=tidepredictions&rows=10000&name=${encodeURIComponent(
     userInput,
   )}`;
 
@@ -58,7 +58,7 @@ export async function getStationsNearCoordinates(
     return cached;
   }
 
-  const url = `${NOAA_MDAPI_BASE}/stations.json?type=tidepredictions&rows=200&lat=${lat}&lon=${lon}&radius=${radiusKm}`;
+  const url = `${NOAA_MDAPI_BASE}/stations.json?type=tidepredictions&rows=10000&lat=${lat}&lon=${lon}&radius=${radiusKm}`;
 
   debugLog('Fetching stations near coordinates', { lat, lon, url });
   const response = await fetch(url);


### PR DESCRIPTION
## Summary
- fetch all NOAA stations by requesting `rows=10000`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686f1b9c6e14832dadb9dbe39f8c1ca8