### PR TITLE
Fix radius station filtering

### DIFF
--- a/src/pages/LocationOnboardingStep1.tsx
+++ b/src/pages/LocationOnboardingStep1.tsx
@@ -107,7 +107,7 @@ const LocationOnboardingStep1 = () => {
 
   const radiusFilteredStations =
     radius && selectedStation
-      ? filteredStations.filter((s) => {
+      ? stations.filter((s) => {
           const dist = getDistanceKm(
             parseFloat(String(selectedStation.lat)),
             parseFloat(String(selectedStation.lng)),


### PR DESCRIPTION
## Summary
- fix the radius filtering logic to ignore the search term when a radius is selected so all nearby stations show up

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686f9915f848832db8095bc4a51aaaf0