### PR TITLE
Update onboarding buttons

### DIFF
--- a/src/pages/LocationOnboardingStep1.tsx
+++ b/src/pages/LocationOnboardingStep1.tsx
@@ -162,18 +162,13 @@ const LocationOnboardingStep1 = () => {
                 </Button>
               ))}
               {selectedStation && (
-                <>
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    onClick={handleClearSelection}
-                  >
-                    <X className="h-4 w-4" />
-                  </Button>
-                  <Button size="sm" onClick={handleContinue}>
-                    Show Tides
-                  </Button>
-                </>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  onClick={handleClearSelection}
+                >
+                  <X className="h-4 w-4" />
+                </Button>
               )}
             </div>
             {error && (
@@ -209,7 +204,7 @@ const LocationOnboardingStep1 = () => {
         )}
 
         <Button disabled={!selectedStation} onClick={handleContinue} className="w-full">
-          Continue
+          Show Tides
         </Button>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- remove "Show Tides" button from the station selector area
- rename the final onboarding button to "Show Tides"

## Testing
- `npm run lint` *(fails: registry access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_686fa8f0e8f4832db7f5ffbd8893a8e6