### PR TITLE
Fix station reset when loading saved location

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -61,7 +61,9 @@ const Index = () => {
     const locationChanged = prevLocationIdRef.current !== currentLocation.id;
     prevLocationIdRef.current = currentLocation.id;
 
-    if (!locationChanged && selectedStation) {
+    // When the location ID matches the selected station ID, we already
+    // have the correct station and should skip any nearby search.
+    if (selectedStation && selectedStation.id === currentLocation.id) {
       if (showStationPicker) setShowStationPicker(false);
       if (availableStations.length !== 0) setAvailableStations([]);
       return;


### PR DESCRIPTION
## Summary
- prevent clearing the selected station when the current location already refers to it

## Testing
- `npm run lint` *(fails: network)*

------
https://chatgpt.com/codex/tasks/task_e_686fb26701a8832d8ba450fa01b2dea3