### PR TITLE
Fix onboarding navigation and cleanup header

### DIFF
--- a/src/components/AppHeader.tsx
+++ b/src/components/AppHeader.tsx
@@ -29,11 +29,6 @@ export default function AppHeader({
               MoonTide
             </h1>
           </div>
-          <div className="flex gap-2">
-            <Link to="/location-onboarding-step1">
-              <Button variant="outline" size="sm">Test Onboarding</Button>
-            </Link>
-          </div>
         </div>
         <div className="flex items-center justify-evenly py-2 w-full">
           <Link to="/fishing-calendar">

--- a/src/pages/LocationOnboardingStep1.tsx
+++ b/src/pages/LocationOnboardingStep1.tsx
@@ -101,7 +101,7 @@ const LocationOnboardingStep1 = ({ onStationSelect }: LocationOnboardingStep1Pro
       onStationSelect(station);
     } else {
       saveStation(station);
-      navigate('/');
+      navigate('/', { replace: true });
     }
   };
 


### PR DESCRIPTION
## Summary
- remove the temporary Test Onboarding link in the header
- replace navigation to main screen when saving station during onboarding

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686fc857746c832dad05a0149e286d47