### PR TITLE
Fix location selector shown after onboarding

### DIFF
--- a/src/hooks/useLocationState.tsx
+++ b/src/hooks/useLocationState.tsx
@@ -37,6 +37,7 @@ const useLocationStateValue = () => {
     try {
       if (location) {
         persistCurrentLocation(location);
+        setShowLocationSelector(false);
       } else {
         clearCurrentLocation();
       }
@@ -71,6 +72,7 @@ const useLocationStateValue = () => {
 
       console.log('🔀 Merged location with station:', mergedLocation);
       setCurrentLocationWithPersist(mergedLocation);
+      setShowLocationSelector(false);
     }
     try {
       safeLocalStorage.set(CURRENT_STATION_KEY, station);


### PR DESCRIPTION
## Summary
- ensure `useLocationState` closes the location selector once a location or station is saved

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6870096dea58832d9581c020482eae08