### PR TITLE
Fix tide station selection when switching saved locations

### DIFF
--- a/src/components/LocationSelector.tsx
+++ b/src/components/LocationSelector.tsx
@@ -67,6 +67,18 @@ export default function LocationSelector({
     };
 
     onSelect(savedLocation);
+
+    if (location.stationId && onStationSelect) {
+      const station: Station = {
+        id: location.stationId,
+        name: location.stationName || location.city,
+        latitude: location.lat ?? 0,
+        longitude: location.lng ?? 0,
+        state: location.state,
+        city: location.city
+      };
+      onStationSelect(station);
+    }
     setIsOpen(false);
   };
 

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -41,6 +41,7 @@ const Index = () => {
   const [showStationPicker, setShowStationPicker] = useState(false);
   const [isStationLoading, setIsStationLoading] = useState(false);
   const prevLocationIdRef = useRef<string | null>(currentLocation?.id || null);
+  const prevStationIdRef = useRef<string | null>(selectedStation?.id || null);
 
   const handleStationSelect = (st: Station) => {
     console.log('🎯 Index onSelect station:', st);
@@ -60,6 +61,8 @@ const Index = () => {
 
     const locationChanged = prevLocationIdRef.current !== currentLocation.id;
     prevLocationIdRef.current = currentLocation.id;
+    const stationChanged = prevStationIdRef.current !== (selectedStation?.id || null);
+    prevStationIdRef.current = selectedStation?.id || null;
 
     // When the location ID matches the selected station ID, we already
     // have the correct station and should skip any nearby search.
@@ -69,7 +72,9 @@ const Index = () => {
       return;
     }
 
-    if (locationChanged && selectedStation) setSelectedStation(null);
+    if (locationChanged && !stationChanged && selectedStation) {
+      setSelectedStation(null);
+    }
 
     const input = currentLocation.zipCode || currentLocation.cityState || currentLocation.name;
     setIsStationLoading(true);


### PR DESCRIPTION
## Summary
- ensure LocationSelector notifies parent of saved station choice
- keep newly selected station when location changes in Index page

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68701380935c832dbe961514178c4a75