### PR TITLE
Add onboarding banner, moon animation, and cleanup fix

### DIFF
--- a/src/components/AppBanner.tsx
+++ b/src/components/AppBanner.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { CloudMoon } from 'lucide-react';
+
+interface AppBannerProps {
+  className?: string;
+}
+
+const AppBanner = ({ className = '' }: AppBannerProps) => (
+  <div className={`flex items-center justify-center gap-2 ${className}`}>
+    <CloudMoon className="h-8 w-8 text-moon-primary" />
+    <h1 className="text-2xl font-bold bg-gradient-to-r from-moon-primary to-moon-blue bg-clip-text text-transparent">
+      MoonTide
+    </h1>
+  </div>
+);
+
+export default AppBanner;

--- a/src/components/MoonAnimation.tsx
+++ b/src/components/MoonAnimation.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+interface MoonAnimationProps {
+  className?: string;
+}
+
+const MoonAnimation = ({ className = '' }: MoonAnimationProps) => (
+  <div className={`flex justify-center mt-6 ${className}`}>
+    <div className="text-6xl animate-float">🌙</div>
+  </div>
+);
+
+export default MoonAnimation;

--- a/src/components/SavedLocationsList.tsx
+++ b/src/components/SavedLocationsList.tsx
@@ -53,12 +53,21 @@ export default function SavedLocationsList({ onLocationSelect, showEmpty = false
       setLocationHistory(updated);
       setDeletingLocation(null);
       toast.success('Location deleted');
-      if (updated.length === 0) {
+      const normalize = (val?: string) => (val || '').trim().toLowerCase();
+      const deletedIsCurrent = currentLocation &&
+        ((deletingLocation.zipCode && currentLocation.zipCode && normalize(deletingLocation.zipCode) === normalize(currentLocation.zipCode)) ||
+         (normalize(deletingLocation.city) === normalize(currentLocation.city) &&
+          normalize(deletingLocation.state) === normalize(currentLocation.state)));
+
+      if (deletedIsCurrent) {
         clearCurrentLocation();
-        clearLocationHistory();
         safeLocalStorage.set('moontide-current-station', null);
         setCurrentLocation(null);
         setSelectedStation(null);
+      }
+
+      if (updated.length === 0) {
+        clearLocationHistory();
       }
     }
   };

--- a/src/pages/LocationOnboardingStep1.tsx
+++ b/src/pages/LocationOnboardingStep1.tsx
@@ -1,5 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import StarsBackdrop from '@/components/StarsBackdrop';
+import AppBanner from '@/components/AppBanner';
+import MoonAnimation from '@/components/MoonAnimation';
 import { Button } from '@/components/ui/button';
 import {
   Select,
@@ -135,6 +137,7 @@ const LocationOnboardingStep1 = ({ onStationSelect }: LocationOnboardingStep1Pro
   return (
     <div className="min-h-screen flex flex-col items-center justify-center relative p-4">
       <StarsBackdrop />
+      <AppBanner className="mb-4 relative z-10" />
       <div className="space-y-4 w-full max-w-md relative z-10">
         <h1 className="text-center text-xl font-bold">Choose a NOAA Station</h1>
 
@@ -216,6 +219,7 @@ const LocationOnboardingStep1 = ({ onStationSelect }: LocationOnboardingStep1Pro
           Show Tides
         </Button>
       </div>
+      <MoonAnimation className="relative z-10" />
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- handle deleting current station cleanly
- add an `AppBanner` component
- add a simple floating moon animation component
- update onboarding screen with banner and animation

## Testing
- `npm run lint`
- `npm run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68701e84be54832d82f7f6077abb709b