### PR TITLE
Add NOAA station favorites and limit onboarding states

### DIFF
--- a/src/hooks/useLocationState.tsx
+++ b/src/hooks/useLocationState.tsx
@@ -2,6 +2,7 @@ import React, { createContext, useState, useEffect, useCallback, useContext } fr
 import { useLocation as useRouterLocation } from 'react-router-dom';
 import { SavedLocation } from '@/components/LocationSelector';
 import { safeLocalStorage } from '@/utils/localStorage';
+import { addFavorite } from '@/utils/stationFavorites';
 import { persistCurrentLocation, loadCurrentLocation, clearCurrentLocation } from '@/utils/currentLocation';
 import { Station } from '@/services/tide/stationService';
 
@@ -73,6 +74,7 @@ const useLocationStateValue = () => {
       console.log('🔀 Merged location with station:', mergedLocation);
       setCurrentLocationWithPersist(mergedLocation);
       setShowLocationSelector(false);
+      addFavorite(station);
     }
     try {
       safeLocalStorage.set(CURRENT_STATION_KEY, station);

--- a/src/pages/LocationOnboardingStep1.tsx
+++ b/src/pages/LocationOnboardingStep1.tsx
@@ -11,12 +11,17 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { Input } from '@/components/ui/input';
-import { Loader2, X } from 'lucide-react';
+import { Loader2, X, Star } from 'lucide-react';
 import { useLocationState } from '@/hooks/useLocationState';
 import { useNavigate } from 'react-router-dom';
 import { STATE_NAME_TO_ABBR } from '@/utils/stateNames';
 import { Station } from '@/services/tide/stationService';
 import { getDistanceKm } from '@/services/tide/geo';
+import {
+  getFavoritesByState,
+  isFavorite,
+  toggleFavorite,
+} from '@/utils/stationFavorites';
 
 interface RawStation {
   id: string;
@@ -27,8 +32,14 @@ interface RawStation {
   city?: string;
 }
 
+const ALLOWED_STATES = [
+  'AL', 'AK', 'CA', 'CT', 'DE', 'FL', 'GA', 'HI', 'LA', 'ME', 'MD', 'MA',
+  'MS', 'NH', 'NJ', 'NY', 'NC', 'OR', 'PA', 'RI', 'SC', 'TX', 'VA', 'WA',
+];
+
 const stateOptions = Object.entries(STATE_NAME_TO_ABBR)
   .map(([name, abbr]) => ({ value: abbr, label: name.replace(/\b\w/g, (l) => l.toUpperCase()) }))
+  .filter((opt) => ALLOWED_STATES.includes(opt.value))
   .sort((a, b) => a.label.localeCompare(b.label));
 
 interface LocationOnboardingStep1Props {
@@ -38,6 +49,7 @@ interface LocationOnboardingStep1Props {
 const LocationOnboardingStep1 = ({ onStationSelect }: LocationOnboardingStep1Props) => {
   const [selectedState, setSelectedState] = useState('');
   const [stations, setStations] = useState<RawStation[]>([]);
+  const [favoriteStations, setFavoriteStations] = useState<RawStation[]>([]);
   const [search, setSearch] = useState('');
   const [selectedStation, setSelectedStation] = useState<RawStation | null>(null);
   const [radius, setRadius] = useState<number | null>(null);
@@ -46,6 +58,10 @@ const LocationOnboardingStep1 = ({ onStationSelect }: LocationOnboardingStep1Pro
 
   const { setSelectedStation: saveStation } = useLocationState();
   const navigate = useNavigate();
+
+  const goToTideScreen = () => {
+    navigate('/', { replace: true });
+  };
 
   // Reset radius filter when the selected station changes
   useEffect(() => {
@@ -56,6 +72,7 @@ const LocationOnboardingStep1 = ({ onStationSelect }: LocationOnboardingStep1Pro
     if (!selectedState) {
       setStations([]);
       setSelectedStation(null);
+      setFavoriteStations([]);
       setError(null);
       return;
     }
@@ -86,6 +103,16 @@ const LocationOnboardingStep1 = ({ onStationSelect }: LocationOnboardingStep1Pro
     };
 
     fetchStations();
+    setFavoriteStations(
+      getFavoritesByState(selectedState).map((s) => ({
+        id: s.id,
+        name: s.name,
+        lat: s.latitude,
+        lng: s.longitude,
+        state: s.state,
+        city: s.city,
+      }))
+    );
   }, [selectedState]);
 
   const handleContinue = () => {
@@ -103,7 +130,7 @@ const LocationOnboardingStep1 = ({ onStationSelect }: LocationOnboardingStep1Pro
       onStationSelect(station);
     } else {
       saveStation(station);
-      navigate('/', { replace: true });
+      goToTideScreen();
     }
   };
 
@@ -188,6 +215,27 @@ const LocationOnboardingStep1 = ({ onStationSelect }: LocationOnboardingStep1Pro
                 {error}
               </div>
             )}
+
+            {favoriteStations.length > 0 && (
+              <div className="border rounded-md divide-y mb-2">
+                {favoriteStations.map((st) => (
+                  <div
+                    key={st.id}
+                    className="p-2 cursor-pointer hover:bg-accent flex items-center justify-between"
+                    onClick={() => setSelectedStation(st)}
+                  >
+                    <div>
+                      <div className="font-medium">{st.name}</div>
+                      <div className="text-xs text-muted-foreground">
+                        {st.city ?? 'Unknown'}, {st.state} - {st.id}
+                      </div>
+                    </div>
+                    <Star className="h-4 w-4 text-yellow-500 fill-yellow-500" />
+                  </div>
+                ))}
+              </div>
+            )}
+
             <div className="max-h-64 overflow-y-auto border rounded-md divide-y">
               {loading && (
                 <div className="p-2 text-sm flex items-center gap-2">
@@ -199,13 +247,43 @@ const LocationOnboardingStep1 = ({ onStationSelect }: LocationOnboardingStep1Pro
                 radiusFilteredStations.map((st) => (
                   <div
                     key={st.id}
-                    className={`p-2 cursor-pointer hover:bg-accent ${selectedStation?.id === st.id ? 'bg-accent' : ''}`}
+                    className={`p-2 cursor-pointer hover:bg-accent flex items-center justify-between ${selectedStation?.id === st.id ? 'bg-accent' : ''}`}
                     onClick={() => setSelectedStation(st)}
                   >
-                    <div className="font-medium">{st.name}</div>
-                    <div className="text-xs text-muted-foreground">
-                      {st.city ?? 'Unknown'}, {st.state} - {st.id} ({st.lat}, {st.lng})
+                    <div>
+                      <div className="font-medium">{st.name}</div>
+                      <div className="text-xs text-muted-foreground">
+                        {st.city ?? 'Unknown'}, {st.state} - {st.id} ({st.lat}, {st.lng})
+                      </div>
                     </div>
+                    <button
+                      className="ml-2 text-yellow-500"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        toggleFavorite({
+                          id: st.id,
+                          name: st.name,
+                          latitude: parseFloat(String(st.lat)),
+                          longitude: parseFloat(String(st.lng)),
+                          state: st.state,
+                          city: st.city,
+                        });
+                        setFavoriteStations(
+                          getFavoritesByState(selectedState).map((s) => ({
+                            id: s.id,
+                            name: s.name,
+                            lat: s.latitude,
+                            lng: s.longitude,
+                            state: s.state,
+                            city: s.city,
+                          }))
+                        );
+                      }}
+                    >
+                      <Star
+                        className={`h-4 w-4 ${isFavorite(st.id) ? 'text-yellow-500 fill-yellow-500' : ''}`}
+                      />
+                    </button>
                   </div>
                 ))}
               {!loading && !error && radiusFilteredStations.length === 0 && (
@@ -217,6 +295,9 @@ const LocationOnboardingStep1 = ({ onStationSelect }: LocationOnboardingStep1Pro
 
         <Button disabled={!selectedStation} onClick={handleContinue} className="w-full">
           Show Tides
+        </Button>
+        <Button variant="outline" onClick={goToTideScreen} className="w-full">
+          Go to Tides
         </Button>
       </div>
       <MoonAnimation className="relative z-10" />

--- a/src/utils/stationFavorites.ts
+++ b/src/utils/stationFavorites.ts
@@ -1,0 +1,61 @@
+export interface FavoriteStation {
+  id: string;
+  name: string;
+  latitude: number;
+  longitude: number;
+  state?: string;
+  city?: string;
+}
+
+import { safeLocalStorage } from './localStorage';
+import { Station } from '@/services/tide/stationService';
+
+const KEY = 'favorite-stations';
+
+function loadFavorites(): FavoriteStation[] {
+  return safeLocalStorage.get<FavoriteStation[]>(KEY) ?? [];
+}
+
+function saveFavorites(list: FavoriteStation[]) {
+  safeLocalStorage.set(KEY, list);
+}
+
+export function getFavorites(): FavoriteStation[] {
+  return loadFavorites();
+}
+
+export function getFavoritesByState(state: string): FavoriteStation[] {
+  const upper = state.toUpperCase();
+  return loadFavorites().filter((s) => (s.state ?? '').toUpperCase() === upper);
+}
+
+export function isFavorite(id: string): boolean {
+  return loadFavorites().some((s) => s.id === id);
+}
+
+export function addFavorite(station: Station): void {
+  const favs = loadFavorites();
+  if (favs.some((s) => s.id === station.id)) return;
+  const entry: FavoriteStation = {
+    id: station.id,
+    name: station.name,
+    latitude: station.latitude,
+    longitude: station.longitude,
+    state: station.state,
+    city: station.city,
+  };
+  saveFavorites([entry, ...favs].slice(0, 20));
+}
+
+export function removeFavorite(id: string): void {
+  const favs = loadFavorites().filter((s) => s.id !== id);
+  saveFavorites(favs);
+}
+
+export function toggleFavorite(station: Station): void {
+  if (isFavorite(station.id)) {
+    removeFavorite(station.id);
+  } else {
+    addFavorite(station);
+  }
+}


### PR DESCRIPTION
## Summary
- allow only supported states on station onboarding
- add favorites utility for tide stations
- store new favorites when selecting a station
- show favorite stations and star icons in onboarding screen
- include button to go directly to tide screen

## Testing
- `npm run lint`
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6870e6d4e008832d9703535d43362f71