### PR TITLE
Move tide chart tooltip above graph

### DIFF
--- a/src/components/TideChart.tsx
+++ b/src/components/TideChart.tsx
@@ -223,8 +223,8 @@ const TideChart = ({
                   content={<CustomTooltip />}
                   wrapperStyle={{
                     left: '50%',
-                    transform: 'translateX(-50%)',
-                    top: 10,
+                    transform: 'translate(-50%, -100%)',
+                    top: 0,
                   }}
                 />
                 <ReferenceLine


### PR DESCRIPTION
## Summary
- adjust tide chart tooltip style to appear above graph to keep the active dot visible

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687103398d48832d9ebdb7d51df25611