### PR TITLE
Fix tide forecast overflow and onboarding visuals

### DIFF
--- a/src/components/TideChart.tsx
+++ b/src/components/TideChart.tsx
@@ -202,11 +202,9 @@ const TideChart = ({
                   dataKey="ts"
                   type="number"
                   domain={[startOfDay.getTime(), endOfRange.getTime()]}
-                  tickFormatter={(t) =>
-                    formatIsoToAmPm(formatDateTimeAsLocalIso(new Date(t)))
-                  }
+                  tickFormatter={() => ''}
                   ticks={tickValues}
-                  tick={{ fill: '#cbd5e1', fontSize: 12 }}
+                  tickLine={false}
                   axisLine={{ stroke: '#475569' }}
                 />
                 <YAxis

--- a/src/hooks/useTideData.tsx
+++ b/src/hooks/useTideData.tsx
@@ -92,11 +92,10 @@ export const useTideData = ({ location, station }: UseTideDataParams): UseTideDa
         startDate.setDate(startDate.getDate() - 1);
         const dateIso = formatDateAsLocalIso(startDate);
 
-        debugLog('Requesting 7 day predictions', { stationId: chosen.id, dateIso });
+        debugLog('Requesting 8 day predictions', { stationId: chosen.id, dateIso });
         const predictions: Prediction[] = await getTideData(
           chosen.id,
-          dateIso,
-          7
+          dateIso
         );
         debugLog('Predictions received', { count: predictions.length });
 

--- a/src/pages/LocationOnboardingStep1.tsx
+++ b/src/pages/LocationOnboardingStep1.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import StarsBackdrop from '@/components/StarsBackdrop';
 import AppBanner from '@/components/AppBanner';
-import MoonAnimation from '@/components/MoonAnimation';
+import MoonVisual from '@/components/MoonVisual';
 import { Button } from '@/components/ui/button';
 import {
   Select,
@@ -160,7 +160,7 @@ const LocationOnboardingStep1 = ({ onStationSelect }: LocationOnboardingStep1Pro
       : filteredStations;
 
   return (
-    <div className="min-h-screen flex flex-col items-center justify-center relative p-4">
+    <div className="min-h-screen flex flex-col items-center justify-center relative p-4 overflow-y-auto">
       <StarsBackdrop />
       <AppBanner className="mb-4 relative z-10" />
       <div className="space-y-4 w-full max-w-md relative z-10">
@@ -268,7 +268,9 @@ const LocationOnboardingStep1 = ({ onStationSelect }: LocationOnboardingStep1Pro
           Go to Tides
         </Button>
       </div>
-      <MoonAnimation className="relative z-10" />
+      <div className="relative z-10 mt-6">
+        <MoonVisual phase="Full Moon" illumination={100} />
+      </div>
     </div>
   );
 };

--- a/src/services/tideDataService.ts
+++ b/src/services/tideDataService.ts
@@ -1,6 +1,6 @@
 // src/services/tideDataService.ts
 //--------------------------------------------------------------
-//  Fetch 7-day tide data for the given NOAA station
+//  Fetch 8-day tide data for the given NOAA station
 //--------------------------------------------------------------
 
 const NOAA_DATA_BASE = 'https://api.tidesandcurrents.noaa.gov/api/prod/datagetter';
@@ -23,7 +23,8 @@ export async function getTideData(
 
   const start = new Date(dateIso);
   const end = new Date(start);
-  end.setDate(start.getDate() + 7);
+  // Fetch one extra day to ensure the last day's cycles are complete
+  end.setDate(start.getDate() + 8);
 
   const format = (d: Date) => d.toISOString().slice(0, 10).replace(/-/g, '');
 


### PR DESCRIPTION
## Summary
- hide tick labels on tide chart x-axis
- fetch an extra day of tide data so each forecast day has two cycles
- remove unused MoonAnimation on onboarding and use purple moon visual
- allow onboarding screen to scroll so action buttons stay in view

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687107e03f44832d95a9d5f7af0e653e