### PR TITLE
Fix mobile layouts

### DIFF
--- a/src/components/AppHeader.tsx
+++ b/src/components/AppHeader.tsx
@@ -22,13 +22,11 @@ export default function AppHeader({
   return (
     <header className="fixed top-0 left-0 right-0 z-50 bg-background/90 backdrop-blur-sm shadow-md">
       <div className="flex flex-col w-full">
-        <div className="flex items-center justify-between py-2 px-4">
-          <div className="flex items-center">
-            <CloudMoon className="h-6 w-6 text-moon-primary mr-2" />
-            <h1 className="text-xl font-bold bg-gradient-to-r from-moon-primary to-moon-blue bg-clip-text text-transparent">
-              MoonTide
-            </h1>
-          </div>
+        <div className="flex items-center justify-center py-2 px-4">
+          <CloudMoon className="h-6 w-6 text-moon-primary mr-2" />
+          <h1 className="text-xl font-bold bg-gradient-to-r from-moon-primary to-moon-blue bg-clip-text text-transparent">
+            MoonTide
+          </h1>
         </div>
         <div className="flex items-center justify-evenly py-2 w-full">
           <Link to="/fishing-calendar">

--- a/src/components/fishing/FishingCalendarHeader.tsx
+++ b/src/components/fishing/FishingCalendarHeader.tsx
@@ -19,14 +19,14 @@ const FishingCalendarHeader: React.FC<FishingCalendarHeaderProps> = ({
   return (
     <header className="py-4 px-4 sm:px-6 lg:px-8">
       <div className="container mx-auto">
-        <div className="flex items-center justify-between">
+        <div className="flex flex-col items-center sm:flex-row sm:justify-between gap-2">
           <div className="flex items-center">
             <CloudMoon className="h-8 w-8 text-moon-primary mr-2" />
             <h1 className="text-2xl font-bold bg-gradient-to-r from-moon-primary to-moon-blue bg-clip-text text-transparent">
               Calendar
             </h1>
           </div>
-          <div className="flex items-center gap-3">
+          <div className="flex flex-col sm:flex-row items-center gap-3">
             <span className="text-sm font-medium hidden md:inline">
               {currentLocation
                 ? <>

--- a/src/components/settings/SettingsItem.tsx
+++ b/src/components/settings/SettingsItem.tsx
@@ -25,7 +25,7 @@ const SettingsItem = ({
   return (
     <Button
       variant="ghost"
-      className="w-full h-auto p-4 flex items-center justify-between hover:bg-gray-700/50 border-b border-gray-700 last:border-b-0 rounded-none"
+      className="w-full h-auto p-4 flex items-center justify-between hover:bg-gray-700/50 border-b border-gray-700 last:border-b-0 rounded-none whitespace-normal"
       onClick={onClick}
     >
       <div className="flex items-center space-x-3">

--- a/src/pages/LocationOnboardingStep1.tsx
+++ b/src/pages/LocationOnboardingStep1.tsx
@@ -160,27 +160,28 @@ const LocationOnboardingStep1 = ({ onStationSelect }: LocationOnboardingStep1Pro
       : filteredStations;
 
   return (
-    <div className="min-h-screen flex flex-col items-center justify-center relative p-4 overflow-y-auto">
+    <div className="min-h-screen flex flex-col relative p-4 overflow-y-auto">
       <StarsBackdrop />
       <AppBanner className="mb-4 relative z-10" />
-      <div className="space-y-4 w-full max-w-md relative z-10">
-        <h1 className="text-center text-xl font-bold">Choose a NOAA Station</h1>
+      <div className="flex flex-col space-y-4 w-full max-w-md relative z-10 flex-grow">
+        <h1 className="text-center text-lg font-bold">Choose a NOAA Station</h1>
 
-        <Select onValueChange={handleStateChange} value={selectedState}>
-          <SelectTrigger>
-            <SelectValue placeholder="Select a state" />
-          </SelectTrigger>
-          <SelectContent className="max-h-60">
-            {stateOptions.map((st) => (
-              <SelectItem key={st.value} value={st.value}>
-                {st.label} ({st.value})
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
+        <div className="flex-grow space-y-2 overflow-y-auto">
+          <Select onValueChange={handleStateChange} value={selectedState}>
+            <SelectTrigger>
+              <SelectValue placeholder="Select a state" />
+            </SelectTrigger>
+            <SelectContent className="max-h-60">
+              {stateOptions.map((st) => (
+                <SelectItem key={st.value} value={st.value}>
+                  {st.label} ({st.value})
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
 
-        {selectedState && (
-          <div className="space-y-2">
+          {selectedState && (
+            <div className="space-y-2">
             <Input
               placeholder="Search stations"
               value={search}
@@ -260,13 +261,16 @@ const LocationOnboardingStep1 = ({ onStationSelect }: LocationOnboardingStep1Pro
             </div>
           </div>
         )}
+        </div>
 
-        <Button disabled={!selectedStation} onClick={handleContinue} className="w-full">
-          Show Tides
-        </Button>
-        <Button variant="outline" onClick={goToTideScreen} className="w-full">
-          Go to Tides
-        </Button>
+        <div className="sticky bottom-0 bg-background pt-4 space-y-2">
+          <Button disabled={!selectedStation} onClick={handleContinue} className="w-full">
+            Show Tides
+          </Button>
+          <Button variant="outline" onClick={goToTideScreen} className="w-full">
+            Go to Tides
+          </Button>
+        </div>
       </div>
       <div className="relative z-10 mt-6">
         <MoonVisual phase="Full Moon" illumination={100} />


### PR DESCRIPTION
## Summary
- center main header title and icon
- keep onboarding buttons visible
- reflow calendar header on small screens
- prevent settings text overflow

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68710e62925c832da7734f53796391c4