### PR TITLE
UI adjustments for onboarding and settings

### DIFF
--- a/src/components/settings/SettingsHeader.tsx
+++ b/src/components/settings/SettingsHeader.tsx
@@ -14,7 +14,7 @@ const SettingsHeader = ({ onBackPress }: SettingsHeaderProps) => {
   };
 
   return (
-    <div className="flex items-center justify-between p-4 border-b border-gray-700">
+    <div className="sticky top-0 z-20 flex items-center justify-between p-4 border-b border-gray-700 bg-background">
       <Button
         variant="ghost"
         size="icon"

--- a/src/pages/LocationOnboardingStep1.tsx
+++ b/src/pages/LocationOnboardingStep1.tsx
@@ -215,7 +215,7 @@ const LocationOnboardingStep1 = ({ onStationSelect }: LocationOnboardingStep1Pro
               </div>
             )}
 
-            <div className="max-h-64 overflow-y-auto border rounded-md divide-y">
+            <div className="max-h-32 overflow-y-auto border rounded-md divide-y">
               {loading && (
                 <div className="p-2 text-sm flex items-center gap-2">
                   <Loader2 className="h-4 w-4 animate-spin" />
@@ -272,7 +272,7 @@ const LocationOnboardingStep1 = ({ onStationSelect }: LocationOnboardingStep1Pro
           </Button>
         </div>
       </div>
-      <div className="relative z-10 mt-6">
+      <div className="relative z-10 mt-6 flex justify-center">
         <MoonVisual phase="Full Moon" illumination={100} />
       </div>
     </div>

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -16,7 +16,7 @@ const Settings = () => {
   };
 
   return (
-    <div className="min-h-screen pb-8 relative">
+    <div className="min-h-screen pb-8 relative overflow-y-auto">
       <StarsBackdrop />
       
       <div className="relative z-10">


### PR DESCRIPTION
## Summary
- adjust station list height so the continue button is visible
- center the moon animation on the onboarding screen
- keep the Settings header fixed at the top

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68711b725ae0832d8f6e9bf812169cc4