### PR TITLE
Fix settings header positioning

### DIFF
--- a/src/components/settings/SettingsHeader.tsx
+++ b/src/components/settings/SettingsHeader.tsx
@@ -14,7 +14,7 @@ const SettingsHeader = ({ onBackPress }: SettingsHeaderProps) => {
   };
 
   return (
-    <div className="sticky top-0 z-20 flex items-center justify-between p-4 border-b border-gray-700 bg-background">
+    <div className="fixed top-0 left-0 right-0 z-50 flex items-center justify-between p-4 border-b border-gray-700 bg-background/90 backdrop-blur-sm shadow-md">
       <Button
         variant="ghost"
         size="icon"

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -16,7 +16,7 @@ const Settings = () => {
   };
 
   return (
-    <div className="min-h-screen pb-8 relative overflow-y-auto">
+    <div className="min-h-screen pb-8 pt-16 relative overflow-y-auto">
       <StarsBackdrop />
       
       <div className="relative z-10">


### PR DESCRIPTION
## Summary
- keep Settings screen header fixed at top
- add padding for the fixed header

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687124439598832d9e5a6de2c3aff70c