### PR TITLE
Fix custom station name editing

### DIFF
--- a/src/components/LocationDisplay.tsx
+++ b/src/components/LocationDisplay.tsx
@@ -12,15 +12,20 @@ interface LocationDisplayProps {
 
 export default function LocationDisplay({ currentLocation, stationName, stationId, hasError }: LocationDisplayProps) {
   const formatLocationDisplay = () => {
-    if (!currentLocation) return "Select a location";
-    
+    if (!currentLocation) return 'Select a location';
+
+    // If the user provided a custom nickname, just show it
+    if (stationName && currentLocation.name && currentLocation.name !== stationName) {
+      return currentLocation.name;
+    }
+
     if (currentLocation.zipCode) {
       return `${currentLocation.name} (${currentLocation.zipCode})`;
     }
     if (currentLocation.name && currentLocation.country) {
       return `${currentLocation.name}, ${currentLocation.country}`;
     }
-    return currentLocation.name || "Select a location";
+    return currentLocation.name || 'Select a location';
   };
 
   // Don't show station info if no location is selected

--- a/src/components/LocationEditModal.tsx
+++ b/src/components/LocationEditModal.tsx
@@ -1,6 +1,11 @@
-
 import React, { useState } from 'react';
-import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '@/components/ui/dialog';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter
+} from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -15,29 +20,19 @@ interface LocationEditModalProps {
 
 export default function LocationEditModal({ location, isOpen, onClose, onSave }: LocationEditModalProps) {
   const [nickname, setNickname] = useState(location.nickname || '');
-  const [city, setCity] = useState(location.city);
-  const [state, setState] = useState(location.state);
-  const [zipCode, setZipCode] = useState(location.zipCode);
 
   const handleSave = () => {
     const updatedLocation: LocationData = {
       ...location,
-      nickname: nickname.trim() || undefined,
-      city: city.trim(),
-      state: state.trim(),
-      zipCode: zipCode.trim()
+      nickname: nickname.trim() || undefined
     };
-    
+
     onSave(updatedLocation);
     onClose();
   };
 
   const handleCancel = () => {
-    // Reset form to original values
     setNickname(location.nickname || '');
-    setCity(location.city);
-    setState(location.state);
-    setZipCode(location.zipCode);
     onClose();
   };
 
@@ -47,53 +42,30 @@ export default function LocationEditModal({ location, isOpen, onClose, onSave }:
         <DialogHeader>
           <DialogTitle>Edit Location</DialogTitle>
         </DialogHeader>
-        
+
         <div className="space-y-4 py-4">
+          {location.stationName && (
+            <div className="space-y-1 text-sm">
+              <Label>Official Name</Label>
+              <p className="text-muted-foreground">{location.stationName}</p>
+            </div>
+          )}
           <div className="space-y-2">
             <Label htmlFor="nickname">Custom Name (Optional)</Label>
             <Input
               id="nickname"
               value={nickname}
               onChange={(e) => setNickname(e.target.value)}
-              placeholder="e.g., Home, Work, Beach House"
-            />
-          </div>
-          
-          <div className="space-y-2">
-            <Label htmlFor="city">City (Optional)</Label>
-              <Input
-                id="city"
-                value={city}
-                onChange={(e) => setCity(e.target.value)}
-              />
-          </div>
-          
-          <div className="space-y-2">
-            <Label htmlFor="state">State (Optional)</Label>
-              <Input
-                id="state"
-                value={state}
-                onChange={(e) => setState(e.target.value)}
-              />
-          </div>
-          
-          <div className="space-y-2">
-            <Label htmlFor="zipCode">ZIP Code</Label>
-            <Input
-              id="zipCode"
-              value={zipCode}
-              onChange={(e) => setZipCode(e.target.value)}
+              placeholder="e.g., Home, Work"
             />
           </div>
         </div>
-        
+
         <DialogFooter>
           <Button variant="outline" onClick={handleCancel}>
             Cancel
           </Button>
-          <Button onClick={handleSave}>
-            Save Changes
-          </Button>
+          <Button onClick={handleSave}>Save Changes</Button>
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/src/utils/locationStorage.ts
+++ b/src/utils/locationStorage.ts
@@ -77,11 +77,12 @@ export const locationStorage = {
       
       // Find and update the location in history
       const updatedHistory = history.map(loc => {
-        // Match by zipCode or city/state combination
+        // Match by stationId or by zipCode/city/state
         const normalize = (val: string | undefined) => (val || '').trim().toLowerCase();
         const normState = (val: string | undefined) =>
           (normalizeStateName(val || '') || normalize(val)).toLowerCase();
         const isMatch =
+          (updatedLocation.stationId && loc.stationId && loc.stationId === updatedLocation.stationId) ||
           (updatedLocation.zipCode && loc.zipCode && normalize(loc.zipCode) === normalize(updatedLocation.zipCode)) ||
           (normalize(loc.city) === normalize(updatedLocation.city) &&
             normState(loc.state) === normState(updatedLocation.state));
@@ -100,6 +101,7 @@ export const locationStorage = {
         const normState = (val: string | undefined) =>
           (normalizeStateName(val || '') || normalize(val)).toLowerCase();
         const isCurrentMatch =
+          (updatedLocation.stationId && currentLocation.stationId && currentLocation.stationId === updatedLocation.stationId) ||
           (updatedLocation.zipCode && currentLocation.zipCode &&
             normalize(currentLocation.zipCode) === normalize(updatedLocation.zipCode)) ||
           (normalize(currentLocation.city) === normalize(updatedLocation.city) &&
@@ -128,6 +130,7 @@ export const locationStorage = {
         (normalizeStateName(val || '') || normalize(val)).toLowerCase();
       const updatedHistory = history.filter(loc => {
         const isMatch =
+          (locationToDelete.stationId && loc.stationId && loc.stationId === locationToDelete.stationId) ||
           (locationToDelete.zipCode && loc.zipCode && normalize(loc.zipCode) === normalize(locationToDelete.zipCode)) ||
           (normalize(loc.city) === normalize(locationToDelete.city) &&
             normState(loc.state) === normState(locationToDelete.state));
@@ -142,6 +145,7 @@ export const locationStorage = {
         const normState = (val: string | undefined) =>
           (normalizeStateName(val || '') || normalize(val)).toLowerCase();
         const isCurrentMatch =
+          (locationToDelete.stationId && currentLocation.stationId && currentLocation.stationId === locationToDelete.stationId) ||
           (locationToDelete.zipCode && currentLocation.zipCode &&
             normalize(currentLocation.zipCode) === normalize(locationToDelete.zipCode)) ||
           (normalize(currentLocation.city) === normalize(locationToDelete.city) &&


### PR DESCRIPTION
## Summary
- adjust `LocationEditModal` so only custom name can be changed and show official station name
- show nickname without extra location info in `LocationDisplay`
- update location storage logic to match/update/delete by station id

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68715bd817a4832dad6f8f302ff4f5f2