### PR TITLE
Add station dedupe to location history

### DIFF
--- a/src/utils/locationStorage.ts
+++ b/src/utils/locationStorage.ts
@@ -26,18 +26,24 @@ export const locationStorage = {
       const normState = (val: string | undefined) =>
         (normalizeStateName(val || '') || normalize(val)).toLowerCase();
       const filtered = history.filter(loc => {
+        const sameStationId =
+          location.stationId && loc.stationId && loc.stationId === location.stationId;
         const sameZip =
           location.zipCode && loc.zipCode && normalize(loc.zipCode) === normalize(location.zipCode);
         const sameCityState =
           normalize(loc.city) === normalize(location.city) &&
           normState(loc.state) === normState(location.state);
 
-        return !(sameZip || sameCityState);
+        return !(sameStationId || sameZip || sameCityState);
       });
-      
-      const newHistory = [locationWithTimestamp, ...filtered].slice(0, 10); // Keep last 10
-      console.log('📝 Saving new history:', newHistory);
-      safeLocalStorage.set(LOCATION_HISTORY_KEY, newHistory);
+
+      const hasMatch = filtered.length !== history.length;
+
+      if (!hasMatch) {
+        const newHistory = [locationWithTimestamp, ...filtered].slice(0, 10); // Keep last 10
+        console.log('📝 Saving new history:', newHistory);
+        safeLocalStorage.set(LOCATION_HISTORY_KEY, newHistory);
+      }
       
       console.log('✅ Location saved successfully');
     } catch (error) {


### PR DESCRIPTION
## Summary
- dedupe stored locations using station ID alongside ZIP and city/state
- only add new history entry when no existing record matches

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6871625fced8832d86fccda594242df2