### PR TITLE
Show nickname with station

### DIFF
--- a/src/components/LocationDisplay.tsx
+++ b/src/components/LocationDisplay.tsx
@@ -14,9 +14,13 @@ export default function LocationDisplay({ currentLocation, stationName, stationI
   const formatLocationDisplay = () => {
     if (!currentLocation) return 'Select a location';
 
-    // If the user provided a custom nickname, just show it
-    if (stationName && currentLocation.name && currentLocation.name !== stationName) {
-      return currentLocation.name;
+    // If the user provided a custom nickname, display it with the station name
+    if (
+      stationName &&
+      currentLocation.name &&
+      currentLocation.name !== stationName
+    ) {
+      return `${currentLocation.name} – ${stationName}`;
     }
 
     if (currentLocation.zipCode) {


### PR DESCRIPTION
## Summary
- show nickname alongside station name in the location header
- keep existing subtext that lists the NOAA station and ID

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6871626222dc832dbacceb17fbe3956b