### PR TITLE
Remove location editing and dedupe saved stations

### DIFF
--- a/src/components/LocationDisplay.tsx
+++ b/src/components/LocationDisplay.tsx
@@ -13,22 +13,7 @@ interface LocationDisplayProps {
 export default function LocationDisplay({ currentLocation, stationName, stationId, hasError }: LocationDisplayProps) {
   const formatLocationDisplay = () => {
     if (!currentLocation) return 'Select a location';
-
-    // If the user provided a custom nickname, display it with the station name
-    if (
-      stationName &&
-      currentLocation.name &&
-      currentLocation.name !== stationName
-    ) {
-      return `${currentLocation.name} – ${stationName}`;
-    }
-
-    if (currentLocation.zipCode) {
-      return `${currentLocation.name} (${currentLocation.zipCode})`;
-    }
-    if (currentLocation.name && currentLocation.country) {
-      return `${currentLocation.name}, ${currentLocation.country}`;
-    }
+    if (stationName) return stationName;
     return currentLocation.name || 'Select a location';
   };
 

--- a/src/utils/locationStorage.ts
+++ b/src/utils/locationStorage.ts
@@ -67,8 +67,17 @@ export const locationStorage = {
   getLocationHistory: (): LocationData[] => {
     try {
       const history = safeLocalStorage.get(LOCATION_HISTORY_KEY) || [];
-      console.log('📚 Retrieved location history:', history);
-      return history;
+      const deduped: LocationData[] = [];
+      const seen = new Set<string>();
+      history.forEach((loc) => {
+        const key = loc.stationId || `${loc.city}-${loc.state}-${loc.zipCode}`;
+        if (!seen.has(key)) {
+          deduped.push(loc);
+          seen.add(key);
+        }
+      });
+      console.log('📚 Retrieved location history:', deduped);
+      return deduped;
     } catch (error) {
       console.error('❌ Error getting location history:', error);
       return [];


### PR DESCRIPTION
## Summary
- hide the edit option in the saved locations list
- simplify location display to always show the station name
- dedupe entries when loading saved location history

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68716a5dae1c832da525ac62019cc89f