### PR TITLE
Fix solar times and enhance layout

### DIFF
--- a/src/components/SolarInfo.tsx
+++ b/src/components/SolarInfo.tsx
@@ -14,35 +14,39 @@ const SolarInfo = ({ solarTimes }: SolarInfoProps) => {
   const isGettingShorter = solarTimes.changeFromPrevious?.includes('-') || solarTimes.changeFromPrevious?.includes('shorter');
 
   return (
-    <div className="bg-muted/20 backdrop-blur-sm py-2 px-3 rounded-lg">
-      <div className="flex justify-between items-center text-xs gap-4">
+    <div className="bg-muted/20 backdrop-blur-sm py-3 px-4 rounded-lg">
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-y-3 text-xs text-center">
         {/* Sunrise */}
-        <div className="flex items-center gap-1">
-          <Sunrise className="h-3 w-3 text-orange-400" />
+        <div className="flex flex-col items-center">
+          <Sunrise className="h-4 w-4 text-orange-400 mb-1" />
+          <span className="text-muted-foreground">Sunrise</span>
           <span className="font-semibold">{solarTimes.sunrise}</span>
         </div>
 
         {/* Sunset */}
-        <div className="flex items-center gap-1">
-          <Sunset className="h-3 w-3 text-red-400" />
+        <div className="flex flex-col items-center">
+          <Sunset className="h-4 w-4 text-red-400 mb-1" />
+          <span className="text-muted-foreground">Sunset</span>
           <span className="font-semibold">{solarTimes.sunset}</span>
         </div>
 
         {/* Total Daylight */}
-        <div className="flex items-center gap-1">
-          <Clock className="h-3 w-3 text-yellow-400" />
+        <div className="flex flex-col items-center">
+          <Clock className="h-4 w-4 text-yellow-400 mb-1" />
+          <span className="text-muted-foreground">Daylight</span>
           <span className="font-semibold text-yellow-400">{solarTimes.daylight}</span>
         </div>
 
-        {/* Change from Previous Day - Always show if available */}
+        {/* Change from Previous Day */}
         {solarTimes.changeFromPrevious && (
-          <div className="flex items-center gap-1">
-            {isGettingLonger && <TrendingUp className="h-3 w-3 text-green-400" />}
-            {isGettingShorter && <TrendingDown className="h-3 w-3 text-red-400" />}
-            {!isGettingLonger && !isGettingShorter && <Clock className="h-3 w-3 text-muted-foreground" />}
+          <div className="flex flex-col items-center">
+            {isGettingLonger && <TrendingUp className="h-4 w-4 text-green-400 mb-1" />}
+            {isGettingShorter && <TrendingDown className="h-4 w-4 text-red-400 mb-1" />}
+            {!isGettingLonger && !isGettingShorter && <Clock className="h-4 w-4 text-muted-foreground mb-1" />}
+            <span className="text-muted-foreground">Change</span>
             <span className={`font-semibold ${
-              isGettingLonger ? 'text-green-400' : 
-              isGettingShorter ? 'text-red-400' : 
+              isGettingLonger ? 'text-green-400' :
+              isGettingShorter ? 'text-red-400' :
               'text-muted-foreground'
             }`}>
               {solarTimes.changeFromPrevious}

--- a/src/pages/FishingCalendar.tsx
+++ b/src/pages/FishingCalendar.tsx
@@ -112,8 +112,12 @@ const Calendar = () => {
       const highTides = allEvents.filter((e) => e.isHigh);
       const lowTides = allEvents.filter((e) => !e.isHigh);
 
-      // Calculate solar times
-      const solarTimes = calculateSolarTimes(date, currentLocation);
+      // Calculate solar times using the user's coordinates when available
+      const solarTimes = calculateSolarTimes(
+        date,
+        currentLocation?.lat ?? 41.4353,
+        currentLocation?.lng ?? -71.4616
+      );
 
       // Calculate optimal fishing windows (example logic)
       const optimalFishingWindows: {


### PR DESCRIPTION
## Summary
- calculate sunrise and sunset using precise coordinates
- improve solar info layout with labels
- pass lat/lng when generating solar times in FishingCalendar

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68716eb41d44832d9c768757e34e2335