### PR TITLE
Add zip-based solar accuracy

### DIFF
--- a/src/components/MoonPhase.tsx
+++ b/src/components/MoonPhase.tsx
@@ -2,11 +2,12 @@ import React from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { cn } from "@/lib/utils";
 import { getFullMoonName, isFullMoon, calculateMoonPhase } from '@/utils/lunarUtils';
-import { calculateSolarTimes } from '@/utils/solarUtils';
+import { calculateSolarTimes, getSolarEvents } from '@/utils/solarUtils';
 import FullMoonBanner from './FullMoonBanner';
 import MoonVisual from './MoonVisual';
 import MoonData from './MoonData';
 import SolarInfo from './SolarInfo';
+import SolarEventInfo from './fishing/SolarEventInfo';
 import { LocationData } from '@/types/locationTypes';
 import { SavedLocation } from './LocationSelector';
 
@@ -72,6 +73,8 @@ const MoonPhase = ({
     [currentDate, lat, lng]
   );
 
+  const solarEvent = getSolarEvents(currentDate);
+
   return (
     <div className="w-full">
       <Card className={cn("overflow-hidden bg-card/50 backdrop-blur-md", className)}>
@@ -96,7 +99,8 @@ const MoonPhase = ({
           />
 
           <div className="border-t border-muted pt-4 w-full space-y-4">
-            <SolarInfo solarTimes={solarTimes} />
+            <SolarInfo solarTimes={solarTimes} zipCode={currentLocation?.zipCode} />
+            {solarEvent && <SolarEventInfo selectedDate={currentDate} />}
           </div>
         </CardContent>
       </Card>

--- a/src/components/SolarInfo.tsx
+++ b/src/components/SolarInfo.tsx
@@ -5,9 +5,10 @@ import { SolarTimes } from '@/utils/solarUtils';
 
 type SolarInfoProps = {
   solarTimes: SolarTimes;
+  zipCode?: string;
 };
 
-const SolarInfo = ({ solarTimes }: SolarInfoProps) => {
+const SolarInfo = ({ solarTimes, zipCode }: SolarInfoProps) => {
   console.log('🌅 SolarInfo received solarTimes:', solarTimes);
   
   const isGettingLonger = solarTimes.changeFromPrevious?.includes('+') || solarTimes.changeFromPrevious?.includes('longer');
@@ -15,7 +16,12 @@ const SolarInfo = ({ solarTimes }: SolarInfoProps) => {
 
   return (
     <div className="bg-muted/20 backdrop-blur-sm py-3 px-4 rounded-lg">
-      <div className="grid grid-cols-2 sm:grid-cols-4 gap-y-3 text-xs text-center">
+      {zipCode && (
+        <div className="text-center text-xs mb-2 text-muted-foreground">
+          ZIP {zipCode}
+        </div>
+      )}
+      <div className="grid grid-cols-2 sm:grid-cols-5 gap-y-3 text-xs text-center">
         {/* Sunrise */}
         <div className="flex flex-col items-center">
           <Sunrise className="h-4 w-4 text-orange-400 mb-1" />
@@ -35,6 +41,13 @@ const SolarInfo = ({ solarTimes }: SolarInfoProps) => {
           <Clock className="h-4 w-4 text-yellow-400 mb-1" />
           <span className="text-muted-foreground">Daylight</span>
           <span className="font-semibold text-yellow-400">{solarTimes.daylight}</span>
+        </div>
+
+        {/* Total Darkness */}
+        <div className="flex flex-col items-center">
+          <Clock className="h-4 w-4 text-blue-400 mb-1" />
+          <span className="text-muted-foreground">Darkness</span>
+          <span className="font-semibold text-blue-400">{solarTimes.darkness}</span>
         </div>
 
         {/* Change from Previous Day */}

--- a/src/hooks/useLocationState.tsx
+++ b/src/hooks/useLocationState.tsx
@@ -66,8 +66,14 @@ const useLocationStateValue = () => {
         id: station.id,
         name: station.name,
         cityState: station.city ? `${station.city}, ${station.state}` : currentLocation?.cityState ?? '',
-        lat: station.latitude,
-        lng: station.longitude
+        lat:
+          currentLocation?.zipCode
+            ? currentLocation.lat ?? station.latitude
+            : station.latitude,
+        lng:
+          currentLocation?.zipCode
+            ? currentLocation.lng ?? station.longitude
+            : station.longitude
       } as SavedLocation & { id: string; country: string };
 
       console.log('🔀 Merged location with station:', mergedLocation);

--- a/src/utils/solarUtils.ts
+++ b/src/utils/solarUtils.ts
@@ -5,6 +5,7 @@ export type SolarTimes = {
   sunset: string;
   daylight: string;
   daylightMinutes: number; // Total daylight in minutes for comparison
+  darkness: string;
   changeFromPrevious?: string; // Change from previous day
 };
 
@@ -79,6 +80,8 @@ export const calculateSolarTimes = (
 
   const daylight = `${Math.floor(current.daylightMinutes / 60)}h ${Math.round(current.daylightMinutes % 60)}m`;
   const daylightMinutes = Math.round(current.daylightMinutes);
+  const darknessMinutes = Math.round(24 * 60 - daylightMinutes);
+  const darkness = `${Math.floor(darknessMinutes / 60)}h ${Math.round(darknessMinutes % 60)}m`;
   const diff = daylightMinutes - Math.round(previous.daylightMinutes);
 
   let changeFromPrevious = '';
@@ -95,6 +98,7 @@ export const calculateSolarTimes = (
     sunset: format(current.sunsetDate),
     daylight,
     daylightMinutes,
+    darkness,
     changeFromPrevious,
   };
 };


### PR DESCRIPTION
## Summary
- allow entering ZIP code during station selection
- persist ZIP location for solar calculations
- preserve zip coordinates when station is saved
- compute darkness length and show in SolarInfo
- show ZIP code and solstice info on tide screen

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687173ddb410832d969c45e85871af6a