### PR TITLE
Improve forecast layout and show solar ZIP

### DIFF
--- a/src/components/LocationDisplay.tsx
+++ b/src/components/LocationDisplay.tsx
@@ -36,11 +36,16 @@ export default function LocationDisplay({ currentLocation, stationName, stationI
 
   return (
     <div className="flex flex-col bg-muted/70 backdrop-blur-sm py-2 px-3 rounded-lg gap-1 mr-2">
-      <div className="flex items-center gap-1">
+      <div className="flex items-center gap-1 flex-wrap">
         <MapPin size={16} className="text-moon-primary" />
         <span className="text-sm font-medium">
           {formatLocationDisplay()}
         </span>
+        {currentLocation.zipCode && (
+          <span className="text-xs text-muted-foreground ml-2">
+            ZIP {currentLocation.zipCode}
+          </span>
+        )}
       </div>
       {/* Station name under ZIP - show helpful message if there's an error even with a station */}
       <div className="text-xs text-muted-foreground pl-5">

--- a/src/components/WeeklyForecast.tsx
+++ b/src/components/WeeklyForecast.tsx
@@ -137,9 +137,9 @@ const WeeklyForecast = ({
                   )}
                 >
                   {/* Day and Date */}
-                  <div className="w-20">
-                    <p className="font-medium">{day.day}</p>
-                    <p className="text-xs text-muted-foreground">{day.date}</p>
+                  <div className="min-w-[7rem]">
+                    <p className="font-medium whitespace-nowrap">{day.day}</p>
+                    <p className="text-xs text-muted-foreground whitespace-nowrap">{day.date}</p>
                   </div>
 
                   {/* Moon Phase */}
@@ -163,8 +163,8 @@ const WeeklyForecast = ({
                   <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 w-full sm:w-auto mt-2 sm:mt-0">
                     {day.cycles.map((cycle, idx) => (
                       <div key={idx} className="text-sm">
-                        <p className="text-xs text-muted-foreground mb-1">Cycle {idx + 1}</p>
-                        <p>
+                        <p className="text-xs text-muted-foreground mb-1 whitespace-nowrap">Cycle {idx + 1}</p>
+                        <p className="whitespace-nowrap">
                           {(cycle.first.isHigh ? 'High' : 'Low')} {formatTimeToAMPM(cycle.first.time)} - {(cycle.second.isHigh ? 'High' : 'Low')} {formatTimeToAMPM(cycle.second.time)}
                         </p>
                       </div>


### PR DESCRIPTION
## Summary
- display the selected ZIP code alongside the location
- keep dates and tide cycles from wrapping in the forecast

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68717d7c45a8832da1824d0bfc849df3