### PR TITLE
Improve forecast layout and solar ZIP note

### DIFF
--- a/src/components/SolarInfo.tsx
+++ b/src/components/SolarInfo.tsx
@@ -17,8 +17,8 @@ const SolarInfo = ({ solarTimes, zipCode }: SolarInfoProps) => {
   return (
     <div className="bg-muted/20 backdrop-blur-sm py-3 px-4 rounded-lg">
       {zipCode && (
-        <div className="text-center text-xs mb-2 text-muted-foreground">
-          ZIP {zipCode}
+        <div className="text-center text-xs font-medium mb-2 text-muted-foreground">
+          Sunrise/Sunset for ZIP {zipCode}
         </div>
       )}
       <div className="grid grid-cols-2 sm:grid-cols-5 gap-y-3 text-xs text-center">

--- a/src/components/WeeklyForecast.tsx
+++ b/src/components/WeeklyForecast.tsx
@@ -132,7 +132,7 @@ const WeeklyForecast = ({
                 <div
                   key={index}
                   className={cn(
-                    "flex flex-col sm:flex-row sm:items-center gap-2 p-3 rounded-md",
+                    "grid gap-3 p-3 rounded-md sm:grid-cols-3 sm:items-center",
                     index === 0 ? "bg-muted" : "hover:bg-muted transition-colors"
                   )}
                 >


### PR DESCRIPTION
## Summary
- tweak solar ZIP display text
- adjust weekly forecast layout for better responsiveness

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68718622af58832da3de2fe360508f94