### PR TITLE
Fix sticky calendar header

### DIFF
--- a/src/components/fishing/FishingCalendarHeader.tsx
+++ b/src/components/fishing/FishingCalendarHeader.tsx
@@ -12,12 +12,12 @@ type FishingCalendarHeaderProps = {
   stationName: string | null;
 };
 
-const FishingCalendarHeader: React.FC<FishingCalendarHeaderProps> = ({ 
-  currentLocation, 
-  stationName 
+const FishingCalendarHeader: React.FC<FishingCalendarHeaderProps> = ({
+  currentLocation,
+  stationName
 }) => {
   return (
-    <header className="py-4 px-4 sm:px-6 lg:px-8">
+    <header className="fixed top-0 left-0 right-0 z-50 bg-background/90 backdrop-blur-sm shadow-md py-4 px-4 sm:px-6 lg:px-8">
       <div className="container mx-auto">
         <div className="flex flex-col items-center sm:flex-row sm:justify-between gap-2">
           <div className="flex items-center">

--- a/src/pages/FishingCalendar.tsx
+++ b/src/pages/FishingCalendar.tsx
@@ -189,7 +189,7 @@ const Calendar = () => {
   const selectedDateInfo = selectedDate ? fishingInfo[format(selectedDate, 'yyyy-MM-dd')] : undefined;
 
   return (
-    <div className="min-h-screen pb-8 relative">
+    <div className="min-h-screen pb-8 pt-24 relative">
       <StarsBackdrop />
 
       <FishingCalendarHeader currentLocation={currentLocation} stationName={stationName} />


### PR DESCRIPTION
## Summary
- keep FishingCalendar header fixed at the top
- add top padding to calendar page so content is not hidden

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6871951fa044832d9b022193f872d172