### PR TITLE
Add normalize util and use in station search

### DIFF
--- a/src/pages/LocationOnboardingStep1.tsx
+++ b/src/pages/LocationOnboardingStep1.tsx
@@ -19,6 +19,7 @@ import { useNavigate } from 'react-router-dom';
 import { STATE_NAME_TO_ABBR } from '@/utils/stateNames';
 import { Station } from '@/services/tide/stationService';
 import { getDistanceKm } from '@/services/tide/geo';
+import { normalize } from '@/utils/normalize';
 import { SavedLocation } from '@/components/LocationSelector';
 import {
   getFavoriteStates,
@@ -179,11 +180,11 @@ const LocationOnboardingStep1 = ({ onStationSelect }: LocationOnboardingStep1Pro
   };
 
   const filteredStations = stations.filter((s) => {
-    const term = search.toLowerCase();
+    const term = normalize(search);
     return (
-      s.name.toLowerCase().includes(term) ||
+      normalize(s.name).includes(term) ||
       (s.city ?? '').toLowerCase().includes(term) ||
-      s.id.includes(term)
+      s.id.toLowerCase().includes(term)
     );
   });
 

--- a/src/utils/normalize.ts
+++ b/src/utils/normalize.ts
@@ -1,0 +1,1 @@
+export const normalize = (s: string) => s.trim().toLowerCase();


### PR DESCRIPTION
## Summary
- add a `normalize` helper for trimming and lowercasing text
- use new helper when filtering stations in LocationOnboardingStep1

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68726604a934832d838cbabb7eb37f25