### PR TITLE
Stop blank screen when cached tides exist

### DIFF
--- a/src/components/LoadingSpinner.tsx
+++ b/src/components/LoadingSpinner.tsx
@@ -1,0 +1,9 @@
+import { Loader2 } from 'lucide-react';
+
+export default function LoadingSpinner() {
+  return (
+    <div className="py-8 text-center text-muted-foreground">
+      <Loader2 className="h-5 w-5 animate-spin inline-block" />
+    </div>
+  );
+}

--- a/src/components/TideChart.tsx
+++ b/src/components/TideChart.tsx
@@ -1,25 +1,24 @@
 import EmptyState from './EmptyState';
 import type { TideDatum } from '@/hooks/useTideData';
+import LoadingSpinner from './LoadingSpinner';
 import { safeArray } from '@/utils/safeArray';
 
 interface Props {
-  tideData: TideDatum[];          // always an array
+  data?: TideDatum[];
   isLoading: boolean;
   error: null | 'no-station' | 'fetch-fail';
 }
-export default function TideChart({ tideData, isLoading, error }: Props) {
-  const data = safeArray(tideData);
-  if (!data.length) {
+export default function TideChart({ data, isLoading, error }: Props) {
+  const rows = safeArray(data);
+
+  if (!rows.length) {
+    if (isLoading) return <LoadingSpinner />;
     return (
       <EmptyState
         text={
-          error === 'no-station'
-            ? 'Pick a location to see tides'
-            : error === 'fetch-fail'
-              ? 'Last fetch failed – retrying…'
-              : isLoading
-                ? 'Loading…'
-                : 'No data cached'
+          error === 'fetch-fail'
+            ? 'Last update failed – retrying…'
+            : 'Pick a location to see tides'
         }
       />
     );

--- a/src/hooks/useTideData.ts
+++ b/src/hooks/useTideData.ts
@@ -29,7 +29,7 @@ export function useTideData(stationId?: string): TideState {
   const cached = readForecast(key);
   const [state, set] = useState<TideState>({
     tideData: cached?.data ?? [],
-    isLoading: false,
+    isLoading: !cached,
     error: null,
     cacheValid: isCacheValid(cached),
   });

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -9,7 +9,7 @@ export default function Index() {
 
   return currentLocation ? (
     <>
-      <TideChart tideData={tideData} isLoading={isLoading} error={error} />
+      <TideChart data={tideData} isLoading={isLoading} error={error} />
     </>
   ) : (
     <LocationOnboardingStep1 />

--- a/src/utils/safeArray.ts
+++ b/src/utils/safeArray.ts
@@ -1,3 +1,2 @@
-export function safeArray<T>(val: T[] | null | undefined): T[] {
-  return Array.isArray(val) ? val : [];
-}
+export const safeArray = <T,>(val?: T[] | null): T[] =>
+  Array.isArray(val) ? val : [];


### PR DESCRIPTION
## Summary
- use cached data to seed `isLoading` in `useTideData`
- rename prop mapping in `Index` page
- bullet‑proof `TideChart` against empty props
- add small spinner component
- expose arrow helper `safeArray`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6873a17d1d4c832dad55d26434ad2716