### PR TITLE
Fix add new stations list refresh

### DIFF
--- a/src/components/SavedLocationsList.tsx
+++ b/src/components/SavedLocationsList.tsx
@@ -1,5 +1,5 @@
 
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { MapPin, Clock, Trash2, MoreVertical } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@/components/ui/dropdown-menu';
@@ -21,6 +21,12 @@ export default function SavedLocationsList({ onLocationSelect, showEmpty = false
   const [locationHistory, setLocationHistory] = useState(locationStorage.getLocationHistory());
   const [deletingLocation, setDeletingLocation] = useState<LocationData | null>(null);
   const { currentLocation, setCurrentLocation, setSelectedStation } = useLocationState();
+
+  useEffect(() => {
+    // Refresh list when the current location changes, ensuring newly added
+    // stations appear immediately in the menu.
+    setLocationHistory(locationStorage.getLocationHistory());
+  }, [currentLocation]);
 
   const handleLocationClick = (location: LocationData): void => {
     onLocationSelect(location);


### PR DESCRIPTION
## Summary
- refresh saved locations list whenever current location changes so newly added stations show up in the Add New menu

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6873b66c8f80832d90314e2cd6025ffe