### PR TITLE
fix offline forecast fallback

### DIFF
--- a/src/hooks/useTideData.tsx
+++ b/src/hooks/useTideData.tsx
@@ -84,7 +84,10 @@ export const useTideData = ({ location, station }: UseTideDataParams): UseTideDa
     const endIso = formatDateAsLocalIso(endDate);
 
     const cacheKey = tideCache.makeKey(station.id, startIso, endIso, 'english');
-    const cached = tideCache.get(cacheKey);
+    let cached = tideCache.get(cacheKey);
+    if (!cached) {
+      cached = tideCache.findLatest(station.id);
+    }
 
     if (cached) {
       setTideData(cached.tideData);

--- a/src/utils/localStorage.ts
+++ b/src/utils/localStorage.ts
@@ -41,6 +41,23 @@ function safeSet<T>(key: string, value: T): void {
   }
 }
 
+function listKeys(prefix = ''): string[] {
+  const keys: string[] = [];
+  try {
+    for (let i = 0; i < window.localStorage.length; i++) {
+      const k = window.localStorage.key(i);
+      if (k && k.startsWith(PREFIX + prefix)) {
+        keys.push(k.slice(PREFIX.length));
+      }
+    }
+  } catch {
+    for (const k of Object.keys(memoryStore)) {
+      if (k.startsWith(prefix)) keys.push(k);
+    }
+  }
+  return keys;
+}
+
 /*───────────────────────────────────────────────────────────*/
 /*  Public API                                               */
 /*───────────────────────────────────────────────────────────*/
@@ -48,9 +65,11 @@ function safeSet<T>(key: string, value: T): void {
 export const safeLocalStorage = {
   get: safeGet,
   set: safeSet,
+  keys: listKeys,
 } as {
   get: typeof safeGet;
   set: typeof safeSet;
+  keys: typeof listKeys;
   getItem?: typeof safeGet;
   setItem?: typeof safeSet;
 };

--- a/src/utils/tideCache.ts
+++ b/src/utils/tideCache.ts
@@ -24,8 +24,26 @@ function setEntry(key: string, entry: TideCacheEntry) {
   safeLocalStorage.set(key, entry);
 }
 
+function findLatestValid(stationId: string): TideCacheEntry | null {
+  const prefix = `${PREFIX}${stationId}:`;
+  const keys = safeLocalStorage.keys(prefix);
+  let latest: TideCacheEntry | null = null;
+
+  for (const key of keys) {
+    const entry = safeLocalStorage.get<TideCacheEntry>(key);
+    if (!entry) continue;
+    if (entry.expiresAt < Date.now()) continue;
+    if (!latest || entry.fetchedAt > latest.fetchedAt) {
+      latest = entry;
+    }
+  }
+
+  return latest;
+}
+
 export const tideCache = {
   makeKey,
   get: getEntry,
   set: setEntry,
+  findLatest: findLatestValid,
 };


### PR DESCRIPTION
## Summary
- add a `keys` helper to localStorage wrapper
- add `findLatest` helper to tide cache
- look for previous forecast if today's cache miss

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6873cb7221bc832d9c6f7eac693a55a8