### PR TITLE
Fix history saving

### DIFF
--- a/src/utils/locationHistory.ts
+++ b/src/utils/locationHistory.ts
@@ -10,7 +10,7 @@ export function getLocationHistory(): LocationHistoryEntry[] {
 export function addLocationHistory(entry: LocationHistoryEntry): void {
   const history = getLocationHistory();
   const filtered = history.filter((h) => h.stationId !== entry.stationId);
-  safeLocalStorage.set(HISTORY_KEY, [entry, ...filtered].slice(0, 20));
+  safeLocalStorage.set(HISTORY_KEY, [entry, ...filtered]);
 }
 
 export function clearLocationHistory(): void {

--- a/src/utils/locationStorage.ts
+++ b/src/utils/locationStorage.ts
@@ -37,7 +37,7 @@ export const locationStorage = {
         return !(sameStationId || sameZip || sameCityState);
       });
 
-      const newHistory = [locationWithTimestamp, ...filtered].slice(0, 10); // Keep last 10
+      const newHistory = [locationWithTimestamp, ...filtered];
       console.log('📝 Saving new history:', newHistory);
       safeLocalStorage.set(LOCATION_HISTORY_KEY, newHistory);
       

--- a/src/utils/stateFavorites.ts
+++ b/src/utils/stateFavorites.ts
@@ -18,7 +18,7 @@ export function addFavoriteState(state: string): void {
   const abbr = state.toUpperCase();
   const favs = loadFavorites();
   if (!favs.includes(abbr)) {
-    saveFavorites([abbr, ...favs].slice(0, 10));
+    saveFavorites([abbr, ...favs]);
   }
 }
 


### PR DESCRIPTION
## Summary
- keep all location and state history entries
- fix overwriting when saving locations and favorites

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6873d6a40140832db011b142436a0c43