### PR TITLE
Fix location overwrite offline

### DIFF
--- a/src/utils/locationStorage.ts
+++ b/src/utils/locationStorage.ts
@@ -31,6 +31,7 @@ export const locationStorage = {
         const sameZip =
           location.zipCode && loc.zipCode && normalize(loc.zipCode) === normalize(location.zipCode);
         const sameCityState =
+          location.city && loc.city &&
           normalize(loc.city) === normalize(location.city) &&
           normState(loc.state) === normState(location.state);
 
@@ -98,7 +99,8 @@ export const locationStorage = {
         const isMatch =
           (updatedLocation.stationId && loc.stationId && loc.stationId === updatedLocation.stationId) ||
           (updatedLocation.zipCode && loc.zipCode && normalize(loc.zipCode) === normalize(updatedLocation.zipCode)) ||
-          (normalize(loc.city) === normalize(updatedLocation.city) &&
+          (updatedLocation.city && loc.city &&
+            normalize(loc.city) === normalize(updatedLocation.city) &&
             normState(loc.state) === normState(updatedLocation.state));
         
         if (isMatch) {
@@ -118,7 +120,8 @@ export const locationStorage = {
           (updatedLocation.stationId && currentLocation.stationId && currentLocation.stationId === updatedLocation.stationId) ||
           (updatedLocation.zipCode && currentLocation.zipCode &&
             normalize(currentLocation.zipCode) === normalize(updatedLocation.zipCode)) ||
-          (normalize(currentLocation.city) === normalize(updatedLocation.city) &&
+          (updatedLocation.city && currentLocation.city &&
+            normalize(currentLocation.city) === normalize(updatedLocation.city) &&
             normState(currentLocation.state) === normState(updatedLocation.state));
         
         if (isCurrentMatch) {
@@ -146,7 +149,8 @@ export const locationStorage = {
         const isMatch =
           (locationToDelete.stationId && loc.stationId && loc.stationId === locationToDelete.stationId) ||
           (locationToDelete.zipCode && loc.zipCode && normalize(loc.zipCode) === normalize(locationToDelete.zipCode)) ||
-          (normalize(loc.city) === normalize(locationToDelete.city) &&
+          (locationToDelete.city && loc.city &&
+            normalize(loc.city) === normalize(locationToDelete.city) &&
             normState(loc.state) === normState(locationToDelete.state));
         return !isMatch;
       });
@@ -162,7 +166,8 @@ export const locationStorage = {
           (locationToDelete.stationId && currentLocation.stationId && currentLocation.stationId === locationToDelete.stationId) ||
           (locationToDelete.zipCode && currentLocation.zipCode &&
             normalize(currentLocation.zipCode) === normalize(locationToDelete.zipCode)) ||
-          (normalize(currentLocation.city) === normalize(locationToDelete.city) &&
+          (locationToDelete.city && currentLocation.city &&
+            normalize(currentLocation.city) === normalize(locationToDelete.city) &&
             normState(currentLocation.state) === normState(locationToDelete.state));
         
         if (isCurrentMatch) {


### PR DESCRIPTION
## Summary
- avoid overwriting saved locations when a station is missing city info
- require city names when matching by city/state

## Testing
- `node -v` *(fails: command not found)*
- `npm --version` *(fails: command not found)*
- `apt-get update` *(fails due to no internet access)*

------
https://chatgpt.com/codex/tasks/task_e_6873db296468832da40c3984fad526f4