### PR TITLE
Remove city geocode for station id

### DIFF
--- a/src/components/StationPicker.tsx
+++ b/src/components/StationPicker.tsx
@@ -108,7 +108,7 @@ export default function StationPicker({ isOpen, stations, onSelect, onClose, cur
                 <SelectContent className="max-h-[200px]">
                   {stations.map((station) => (
                     <SelectItem key={station.id} value={station.id}>
-                      {station.name} ({station.id}) {station.city && `- ${station.city}, ${station.state}`}
+                      {station.name} ({station.id}){station.state ? ` - ${station.state}` : ''}
                     </SelectItem>
                   ))}
                 </SelectContent>

--- a/src/pages/LocationOnboardingStep1.tsx
+++ b/src/pages/LocationOnboardingStep1.tsx
@@ -294,7 +294,7 @@ const LocationOnboardingStep1 = ({ onStationSelect }: LocationOnboardingStep1Pro
                     <div>
                       <div className="font-medium">{st.name}</div>
                       <div className="text-xs text-muted-foreground">
-                        {st.city ?? 'Unknown'}, {st.state} - {st.id} ({st.lat}, {st.lng})
+                        {st.state} - {st.id} ({st.lat}, {st.lng})
                       </div>
                     </div>
                   </div>


### PR DESCRIPTION
## Summary
- remove city details from manual station selection UI
- remove city column from onboarding station list

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6875058c5208832da06d41210be6aed4