### PR TITLE
Fix station history overwriting

### DIFF
--- a/src/utils/locationHistory.ts
+++ b/src/utils/locationHistory.ts
@@ -9,8 +9,9 @@ export function getLocationHistory(): LocationHistoryEntry[] {
 
 export function addLocationHistory(entry: LocationHistoryEntry): void {
   const history = getLocationHistory();
-  const filtered = history.filter((h) => h.stationId !== entry.stationId);
-  safeLocalStorage.set(HISTORY_KEY, [entry, ...filtered]);
+  // Always append new entries instead of replacing existing ones so we
+  // preserve the full history of stations the user has selected.
+  safeLocalStorage.set(HISTORY_KEY, [entry, ...history]);
 }
 
 export function clearLocationHistory(): void {

--- a/src/utils/locationStorage.ts
+++ b/src/utils/locationStorage.ts
@@ -21,24 +21,9 @@ export const locationStorage = {
       const history = locationStorage.getLocationHistory();
       console.log('📚 Current history:', history);
       
-      // Remove any existing entry that matches this location to avoid duplicates
-      const normalize = (val: string | undefined) => (val || '').trim().toLowerCase();
-      const normState = (val: string | undefined) =>
-        (normalizeStateName(val || '') || normalize(val)).toLowerCase();
-
-      const filteredHistory = history.filter((loc) => {
-        const matchByStation =
-          location.stationId && loc.stationId && loc.stationId === location.stationId;
-        const matchByZip =
-          location.zipCode && loc.zipCode && normalize(loc.zipCode) === normalize(location.zipCode);
-        const matchByCityState =
-          location.city && loc.city &&
-          normalize(loc.city) === normalize(location.city) &&
-          normState(loc.state) === normState(location.state);
-        return !(matchByStation || matchByZip || matchByCityState);
-      });
-
-      const newHistory = [locationWithTimestamp, ...filteredHistory];
+      // Always append new entries instead of overwriting existing ones so we
+      // retain a complete history of selected locations.
+      const newHistory = [locationWithTimestamp, ...history];
       console.log('📝 Saving new history:', newHistory);
       safeLocalStorage.set(LOCATION_HISTORY_KEY, newHistory);
       


### PR DESCRIPTION
## Summary
- keep full station history instead of overwriting

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68750c6d8314832da643ed140b8e9de9