### PR TITLE
Use custom MoonTide SVG

### DIFF
--- a/src/assets/MoonTideIcon.svg
+++ b/src/assets/MoonTideIcon.svg
@@ -1,0 +1,11 @@
+<!-- MoonTideIcon.svg  | 24×24 | stroke = currentColor -->
+<svg xmlns="http://www.w3.org/2000/svg"
+     viewBox="0 0 24 24"
+     fill="none"
+     stroke="currentColor"
+     stroke-width="2"
+     stroke-linecap="round"
+     stroke-linejoin="round">
+  <circle cx="12" cy="8" r="5"/>
+  <path d="M2 16c2-2 6-2 8 0s6 2 8 0"/>
+</svg>

--- a/src/components/AppBanner.tsx
+++ b/src/components/AppBanner.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { CloudMoon } from 'lucide-react';
+import MoonTideIcon from '@/assets/MoonTideIcon.svg';
 
 interface AppBannerProps {
   className?: string;
@@ -7,7 +7,7 @@ interface AppBannerProps {
 
 const AppBanner = ({ className = '' }: AppBannerProps) => (
   <div className={`flex items-center justify-center gap-2 ${className}`}>
-    <CloudMoon className="h-8 w-8 text-moon-primary" />
+    <MoonTideIcon className="h-8 w-8 text-moon-primary" />
     <h1 className="text-2xl font-bold bg-gradient-to-r from-moon-primary to-moon-blue bg-clip-text text-transparent">
       MoonTide
     </h1>

--- a/src/components/AppHeader.tsx
+++ b/src/components/AppHeader.tsx
@@ -1,7 +1,8 @@
 
 import React from 'react';
 import { Link } from 'react-router-dom';
-import { CloudMoon, Calendar, Settings, MapPin } from "lucide-react";
+import { Calendar, Settings, MapPin } from "lucide-react";
+import MoonTideIcon from "@/assets/MoonTideIcon.svg";
 import { Button } from "@/components/ui/button";
 import LocationSelector, { SavedLocation } from './LocationSelector';
 import { Station } from '@/services/tide/stationService';
@@ -23,7 +24,7 @@ export default function AppHeader({
     <header className="fixed top-0 left-0 right-0 z-50 bg-background/90 backdrop-blur-sm shadow-md">
       <div className="flex flex-col w-full">
         <div className="flex items-center justify-center py-2 px-4">
-          <CloudMoon className="h-6 w-6 text-moon-primary mr-2" />
+          <MoonTideIcon className="h-6 w-6 text-moon-primary mr-2" />
           <h1 className="text-xl font-bold bg-gradient-to-r from-moon-primary to-moon-blue bg-clip-text text-transparent">
             MoonTide
           </h1>

--- a/src/types/svg.d.ts
+++ b/src/types/svg.d.ts
@@ -1,0 +1,5 @@
+declare module '*.svg' {
+  import * as React from 'react';
+  const ReactComponent: React.FC<React.SVGProps<SVGSVGElement>>;
+  export default ReactComponent;
+}


### PR DESCRIPTION
## Summary
- add MoonTide icon asset and SVG types
- replace Lucide `CloudMoon` icons in AppHeader and AppBanner

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68751a7ddb14832d96e8d43de6671d06