### PR TITLE
Fix custom icon integration

### DIFF
--- a/src/components/AppBanner.tsx
+++ b/src/components/AppBanner.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import MoonTideIcon from '@/assets/MoonTideIcon.svg';
+import MoonTideIcon from './MoonTideIcon';
 
 interface AppBannerProps {
   className?: string;

--- a/src/components/AppHeader.tsx
+++ b/src/components/AppHeader.tsx
@@ -2,7 +2,7 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import { Calendar, Settings, MapPin } from "lucide-react";
-import MoonTideIcon from "@/assets/MoonTideIcon.svg";
+import MoonTideIcon from "./MoonTideIcon";
 import { Button } from "@/components/ui/button";
 import LocationSelector, { SavedLocation } from './LocationSelector';
 import { Station } from '@/services/tide/stationService';

--- a/src/components/MoonTideIcon.tsx
+++ b/src/components/MoonTideIcon.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+
+export default function MoonTideIcon(props: React.SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      {...props}
+    >
+      <circle cx="12" cy="8" r="5" />
+      <path d="M2 16c2-2 6-2 8 0s6 2 8 0" />
+    </svg>
+  );
+}

--- a/src/types/svg.d.ts
+++ b/src/types/svg.d.ts
@@ -1,5 +1,0 @@
-declare module '*.svg' {
-  import * as React from 'react';
-  const ReactComponent: React.FC<React.SVGProps<SVGSVGElement>>;
-  export default ReactComponent;
-}


### PR DESCRIPTION
## Summary
- export custom MoonTide icon as a React component
- drop svg.d.ts type helper
- update AppBanner and AppHeader to import the new component

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68751e42a444832d87b5dda1acabb832