### PR TITLE
Fix station overwriting issues

### DIFF
--- a/src/utils/locationStorage.ts
+++ b/src/utils/locationStorage.ts
@@ -28,7 +28,8 @@ export const locationStorage = {
       const isSame = (a: LocationData, b: LocationData) =>
         (a.stationId && b.stationId && a.stationId === b.stationId) ||
         (a.zipCode && b.zipCode && normalize(a.zipCode) === normalize(b.zipCode)) ||
-        (normalize(a.city) === normalize(b.city) &&
+        (a.city && b.city &&
+          normalize(a.city) === normalize(b.city) &&
           normState(a.state) === normState(b.state));
 
       const filteredHistory = history.filter((h) => !isSame(h, locationWithTimestamp));


### PR DESCRIPTION
## Summary
- prevent station overwriting in saved location history by requiring a city on both entries before matching

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687526b5ff2c832d95444cef0439fda4