### PR TITLE
Fix location history duplication

### DIFF
--- a/src/utils/locationHistory.ts
+++ b/src/utils/locationHistory.ts
@@ -9,9 +9,15 @@ export function getLocationHistory(): LocationHistoryEntry[] {
 
 export function addLocationHistory(entry: LocationHistoryEntry): void {
   const history = getLocationHistory();
-  // Always append new entries instead of replacing existing ones so we
-  // preserve the full history of stations the user has selected.
-  safeLocalStorage.set(HISTORY_KEY, [entry, ...history]);
+
+  // Filter out any identical entry (same station and timestamp) so
+  // repeated calls don't create duplicates or overwrite earlier records.
+  const filtered = history.filter(
+    (h) => !(h.stationId === entry.stationId && h.timestamp === entry.timestamp)
+  );
+
+  // Append the new entry while keeping prior unique ones intact.
+  safeLocalStorage.set(HISTORY_KEY, [entry, ...filtered]);
 }
 
 export function clearLocationHistory(): void {


### PR DESCRIPTION
## Summary
- avoid overwriting recent station history by filtering duplicates before saving

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68752ef07550832d9298c40ea5553063