### PR TITLE
Fix station history dedupe

### DIFF
--- a/src/utils/locationHistory.ts
+++ b/src/utils/locationHistory.ts
@@ -12,10 +12,13 @@ export function addLocationHistory(entry: LocationHistoryEntry): void {
 
   // Remove any previous entry for this station so selecting the same
   // station again updates its timestamp rather than creating a duplicate.
-  const filtered = history.filter((h) => h.stationId !== entry.stationId);
+  const id = String(entry.stationId).trim();
+  const filtered = history.filter((h) => String(h.stationId).trim() !== id);
+
+  const normalizedEntry = { ...entry, stationId: id } as LocationHistoryEntry;
 
   // Prepend the new entry, keeping the rest of the history intact.
-  safeLocalStorage.set(HISTORY_KEY, [entry, ...filtered]);
+  safeLocalStorage.set(HISTORY_KEY, [normalizedEntry, ...filtered]);
 }
 
 export function clearLocationHistory(): void {

--- a/src/utils/locationStorage.ts
+++ b/src/utils/locationStorage.ts
@@ -28,7 +28,11 @@ export const locationStorage = {
 
       const isSame = (a: LocationData, b: LocationData) => {
         if (a.stationId || b.stationId) {
-          return Boolean(a.stationId && b.stationId && a.stationId === b.stationId);
+          return Boolean(
+            a.stationId &&
+            b.stationId &&
+            String(a.stationId).trim() === String(b.stationId).trim()
+          );
         }
         if (a.zipCode && b.zipCode) {
           return normalize(a.zipCode) === normalize(b.zipCode);
@@ -89,7 +93,11 @@ export const locationStorage = {
           (normalizeStateName(val || '') || normalize(val)).toLowerCase();
         const isMatch = (() => {
           if (updatedLocation.stationId || loc.stationId) {
-            return Boolean(updatedLocation.stationId && loc.stationId && loc.stationId === updatedLocation.stationId);
+            return Boolean(
+              updatedLocation.stationId &&
+              loc.stationId &&
+              String(loc.stationId).trim() === String(updatedLocation.stationId).trim()
+            );
           }
           if (updatedLocation.zipCode && loc.zipCode) {
             return normalize(loc.zipCode) === normalize(updatedLocation.zipCode);
@@ -116,7 +124,12 @@ export const locationStorage = {
           (normalizeStateName(val || '') || normalize(val)).toLowerCase();
         const isCurrentMatch = (() => {
           if (updatedLocation.stationId || currentLocation.stationId) {
-            return Boolean(updatedLocation.stationId && currentLocation.stationId && currentLocation.stationId === updatedLocation.stationId);
+            return Boolean(
+              updatedLocation.stationId &&
+              currentLocation.stationId &&
+              String(currentLocation.stationId).trim() ===
+                String(updatedLocation.stationId).trim()
+            );
           }
           if (updatedLocation.zipCode && currentLocation.zipCode) {
             return normalize(currentLocation.zipCode) === normalize(updatedLocation.zipCode);
@@ -152,7 +165,12 @@ export const locationStorage = {
       const updatedHistory = history.filter(loc => {
         const isMatch = (() => {
           if (locationToDelete.stationId || loc.stationId) {
-            return Boolean(locationToDelete.stationId && loc.stationId && loc.stationId === locationToDelete.stationId);
+            return Boolean(
+              locationToDelete.stationId &&
+              loc.stationId &&
+              String(loc.stationId).trim() ===
+                String(locationToDelete.stationId).trim()
+            );
           }
           if (locationToDelete.zipCode && loc.zipCode) {
             return normalize(loc.zipCode) === normalize(locationToDelete.zipCode);
@@ -175,7 +193,12 @@ export const locationStorage = {
           (normalizeStateName(val || '') || normalize(val)).toLowerCase();
         const isCurrentMatch = (() => {
           if (locationToDelete.stationId || currentLocation.stationId) {
-            return Boolean(locationToDelete.stationId && currentLocation.stationId && currentLocation.stationId === locationToDelete.stationId);
+            return Boolean(
+              locationToDelete.stationId &&
+              currentLocation.stationId &&
+              String(currentLocation.stationId).trim() ===
+                String(locationToDelete.stationId).trim()
+            );
           }
           if (locationToDelete.zipCode && currentLocation.zipCode) {
             return normalize(currentLocation.zipCode) === normalize(locationToDelete.zipCode);


### PR DESCRIPTION
## Summary
- normalize station IDs when saving history
- compare station IDs as strings to avoid duplicates

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68753881e698832d8b008ba1cccc859c