### PR TITLE
Fix station history dedupe for ZIP-based reselects

### DIFF
--- a/src/utils/currentLocation.ts
+++ b/src/utils/currentLocation.ts
@@ -60,29 +60,18 @@ export function persistStationCurrentLocation(station?: Station | null) {
 
 export function persistCurrentLocation(location: SavedLocation & { id: string; country: string }) {
   const [city, state] = location.cityState.split(', ');
-  const storageObj = location.zipCode
-    ? {
-        zipCode: location.zipCode,
-        city: city || location.name,
-        state: state || '',
-        lat: location.lat,
-        lng: location.lng,
-        stationId: undefined,
-        stationName: undefined,
-        nickname: location.name !== city ? location.name : undefined,
-        isManual: false,
-      }
-    : {
-        stationId: location.id,
-        stationName: location.name,
-        state: state || '',
-        lat: location.lat,
-        lng: location.lng,
-        zipCode: location.zipCode || '',
-        city: city || '',
-        nickname: location.name !== city ? location.name : undefined,
-        isManual: false,
-      };
+  const isStationId = /^\d{7}$/.test(location.id);
+  const storageObj = {
+    zipCode: location.zipCode || '',
+    city: city || location.name,
+    state: state || '',
+    lat: location.lat,
+    lng: location.lng,
+    stationId: isStationId ? location.id : undefined,
+    stationName: isStationId ? location.name : undefined,
+    nickname: location.name !== city ? location.name : undefined,
+    isManual: false,
+  };
 
   console.log('Saving current location to storage:', storageObj);
   safeLocalStorage.set(CURRENT_LOCATION_KEY, storageObj);

--- a/src/utils/locationStorage.ts
+++ b/src/utils/locationStorage.ts
@@ -27,11 +27,21 @@ export const locationStorage = {
         (normalizeStateName(val || '') || normalize(val));
 
       const isSame = (a: LocationData, b: LocationData) => {
+        if (a.stationId && b.stationId) {
+          return String(a.stationId).trim() === String(b.stationId).trim();
+        }
         if (a.stationId || b.stationId) {
-          return Boolean(
-            a.stationId &&
-            b.stationId &&
-            String(a.stationId).trim() === String(b.stationId).trim()
+          // When only one has a stationId, fall back to comparing
+          // ZIP or city/state so reselecting a station with saved
+          // ZIP code doesn't create duplicates.
+          if (a.zipCode && b.zipCode) {
+            return normalize(a.zipCode) === normalize(b.zipCode);
+          }
+          return (
+            a.city &&
+            b.city &&
+            normalize(a.city) === normalize(b.city) &&
+            normState(a.state) === normState(b.state)
           );
         }
         if (a.zipCode && b.zipCode) {


### PR DESCRIPTION
## Summary
- always store stationId if location id looks like one
- fall back to ZIP/city check when only one history entry has a stationId

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68754f8c6874832da8aa2b3b8f312936