### PR TITLE
Fix station dedup with strict id validation

### DIFF
--- a/src/components/LocationManager.tsx
+++ b/src/components/LocationManager.tsx
@@ -14,27 +14,24 @@ interface LocationManagerProps {
 const LocationManager = ({ setCurrentLocation, setShowLocationSelector }: LocationManagerProps) => {
   const handleLocationChange = (location: SavedLocation) => {
     console.log('🔄 LocationManager: Location change requested:', location);
-    
-    const updatedLocation = {
-      ...location,
-      id: location.id || location.zipCode || "temp",
-      country: location.country || "USA",
-      name: location.name || `${location.zipCode || "Unknown Location"}`
-    };
-    
-    console.log('🔄 LocationManager: Calling setCurrentLocation');
-    setCurrentLocation(updatedLocation);
-    
-    // Save to storage
     try {
+      const normalized = normalizeStation({ stationId: location.id });
+      const updatedLocation = {
+        ...location,
+        id: normalized.stationId,
+        country: location.country || 'USA',
+        name: location.name || normalized.stationName,
+      };
+      console.log('🔄 LocationManager: Calling setCurrentLocation');
+      setCurrentLocation(updatedLocation);
       persistCurrentLocation(updatedLocation);
       console.log('💾 LocationManager: Location saved successfully');
+      setShowLocationSelector(false);
+      toast.success(`Loading tide data for ${updatedLocation.name}`);
     } catch (error) {
-      console.error('❌ LocationManager: Error saving location:', error);
+      console.error('❌ LocationManager: Invalid station:', error);
+      toast.error('Invalid station ID');
     }
-    
-    setShowLocationSelector(false);
-    toast.success(`Loading tide data for ${updatedLocation.name}`);
   };
 
   const onSelectStation = (station: Station) => {
@@ -68,19 +65,18 @@ const LocationManager = ({ setCurrentLocation, setShowLocationSelector }: Locati
 
   const handleGetStarted = (location?: LocationData) => {
     console.log('🔄 LocationManager: handleGetStarted called with:', location);
-    
+
     if (location) {
       const savedLocation: SavedLocation = {
-        id: location.zipCode || location.city,
+        id: location.stationId || '',
         name: location.nickname || location.city,
-        country: "USA",
+        country: 'USA',
         zipCode: location.zipCode || '',
         cityState: `${location.city}, ${location.state}`,
         lat: location.lat ?? null,
-        lng: location.lng ?? null
+        lng: location.lng ?? null,
       };
-      
-      console.log('🔄 LocationManager: Converting and setting location');
+
       handleLocationChange(savedLocation);
     } else {
       console.log('🔄 LocationManager: No location provided, showing selector');

--- a/src/components/SavedLocationsList.tsx
+++ b/src/components/SavedLocationsList.tsx
@@ -114,12 +114,11 @@ export default function SavedLocationsList({ onLocationSelect, showEmpty = false
     <>
       <div className="space-y-2 max-h-40 overflow-y-auto">
         {locationHistory.map((location, index) => {
-          const isCurrent = currentLocation?.zipCode === location.zipCode || 
-                           (currentLocation?.city === location.city && currentLocation?.state === location.state);
+          const isCurrent = currentLocation?.id === location.stationId;
           
           return (
             <div
-              key={`${location.zipCode || location.city}-${index}`}
+              key={`${location.stationId}-${index}`}
               className={`w-full justify-start h-auto p-3 text-left border rounded-lg cursor-pointer transition-colors ${
                 isCurrent ? 'bg-secondary border-primary/20' : 'border-border hover:bg-accent'
               }`}


### PR DESCRIPTION
## Summary
- validate NOAA station IDs when storing or updating locations
- replace temp/fallback station IDs in LocationManager
- compare saved locations by station ID only
- sanitize saved locations on load

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68765cc8329c832db6759bc56ac00292