### PR TITLE
Enforce numeric NOAA station IDs

### DIFF
--- a/src/components/LocationManager.tsx
+++ b/src/components/LocationManager.tsx
@@ -5,6 +5,8 @@ import { LocationData } from '@/types/locationTypes';
 import { persistCurrentLocation, clearCurrentLocation, persistStationCurrentLocation } from '@/utils/currentLocation';
 
 import { normalizeStation, saveStationHistory } from "@/services/storage/locationHistory";
+
+const NUMERIC_ID_RE = /^\d+$/;
 import type { Station } from "@/services/tide/stationService";
 interface LocationManagerProps {
   setCurrentLocation: (location: SavedLocation & { id: string; country: string } | null) => void;
@@ -14,6 +16,11 @@ interface LocationManagerProps {
 const LocationManager = ({ setCurrentLocation, setShowLocationSelector }: LocationManagerProps) => {
   const handleLocationChange = (location: SavedLocation) => {
     console.log('🔄 LocationManager: Location change requested:', location);
+    if (!location.id || !NUMERIC_ID_RE.test(location.id)) {
+      console.error('Invalid station ID');
+      toast.error('Invalid station ID');
+      return;
+    }
     try {
       const normalized = normalizeStation({ stationId: location.id });
       const updatedLocation = {
@@ -36,6 +43,11 @@ const LocationManager = ({ setCurrentLocation, setShowLocationSelector }: Locati
 
   const onSelectStation = (station: Station) => {
     console.log('🔄 LocationManager: Station selected:', station);
+    if (!station.id || !NUMERIC_ID_RE.test(String(station.id))) {
+      console.error('Invalid station ID');
+      toast.error('Invalid station ID');
+      return;
+    }
     const normalized = normalizeStation(station);
     try {
       persistStationCurrentLocation(normalized);
@@ -67,8 +79,13 @@ const LocationManager = ({ setCurrentLocation, setShowLocationSelector }: Locati
     console.log('🔄 LocationManager: handleGetStarted called with:', location);
 
     if (location) {
+      if (!location.stationId || !NUMERIC_ID_RE.test(location.stationId)) {
+        console.error('Invalid station ID');
+        toast.error('Invalid station ID');
+        return;
+      }
       const savedLocation: SavedLocation = {
-        id: location.stationId || '',
+        id: location.stationId,
         name: location.nickname || location.city,
         country: 'USA',
         zipCode: location.zipCode || '',

--- a/src/components/LocationSelector.tsx
+++ b/src/components/LocationSelector.tsx
@@ -7,6 +7,7 @@ import { LocationData } from '@/types/locationTypes';
 import SavedLocationsList from './SavedLocationsList';
 import { Station } from '@/services/tide/stationService';
 import { useNavigate } from 'react-router-dom';
+const NUMERIC_ID_RE = /^\d+$/;
 
 // Keep the SavedLocation interface for backward compatibility
 export interface SavedLocation {
@@ -54,10 +55,16 @@ export default function LocationSelector({
 
   const handleSavedLocationSelect = (location: LocationData): void => {
     console.log('📍 Saved location selected:', location);
-    
+
+    if (!location.stationId || !NUMERIC_ID_RE.test(location.stationId)) {
+      console.error('Invalid station ID');
+      onClose?.();
+      return;
+    }
+
     // Convert LocationData to SavedLocation format for compatibility
     const savedLocation: SavedLocation = {
-      id: location.zipCode || location.city,
+      id: location.stationId,
       name: location.nickname || location.city,
       country: 'USA',
       zipCode: location.zipCode,
@@ -68,7 +75,7 @@ export default function LocationSelector({
 
     onSelect(savedLocation);
 
-    if (location.stationId && onStationSelect) {
+    if (onStationSelect) {
       const station: Station = {
         id: location.stationId,
         name: location.stationName || location.city,

--- a/src/hooks/useLocationState.tsx
+++ b/src/hooks/useLocationState.tsx
@@ -6,6 +6,7 @@ import { persistCurrentLocation, loadCurrentLocation, clearCurrentLocation } fro
 import { Station } from '@/services/tide/stationService';
 
 const CURRENT_STATION_KEY = 'moontide-current-station';
+const NUMERIC_ID_RE = /^\d+$/;
 
 function getInitialLocation(): (SavedLocation & { id: string; country: string }) | null {
   try {
@@ -19,7 +20,7 @@ function getInitialLocation(): (SavedLocation & { id: string; country: string })
 function getInitialStation(): Station | null {
   try {
     const saved = safeLocalStorage.get(CURRENT_STATION_KEY);
-    return saved?.id ? saved as Station : null;
+    return saved?.id && NUMERIC_ID_RE.test(String(saved.id)) ? (saved as Station) : null;
   } catch {
     return null;
   }
@@ -36,6 +37,10 @@ const useLocationStateValue = () => {
     setCurrentLocation(location);
     try {
       if (location) {
+        if (!NUMERIC_ID_RE.test(location.id)) {
+          console.error('Invalid station ID');
+          return;
+        }
         persistCurrentLocation(location);
         setShowLocationSelector(false);
       } else {
@@ -49,6 +54,10 @@ const useLocationStateValue = () => {
   const setSelectedStationWithPersist = useCallback((station: Station | null) => {
     setSelectedStation(station);
     if (station) {
+      if (!NUMERIC_ID_RE.test(String(station.id))) {
+        console.error('Invalid station ID');
+        return;
+      }
       console.log('Station selected:', station.id, station.name);
     }
     if (station) {

--- a/src/utils/locationStorage.ts
+++ b/src/utils/locationStorage.ts
@@ -1,16 +1,16 @@
 import { safeLocalStorage } from './localStorage';
 import { LocationData } from '@/types/locationTypes';
-import { normalizeStation, type SavedLocation as StoredLocation } from '@/services/storage/locationHistory';
+import type { SavedLocation as StoredLocation } from '@/services/storage/locationHistory';
 
 const CURRENT_LOCATION_KEY = 'current-location-data';
 const LOCATION_HISTORY_KEY = 'location-history';
 
+const NUMERIC_ID_RE = /^\d+$/;
+
 function validId(record: Partial<LocationData>): string | null {
-  try {
-    return normalizeStation(record as Partial<StoredLocation>).stationId;
-  } catch {
-    return null;
-  }
+  const raw = String(record.stationId ?? '').trim();
+  if (!NUMERIC_ID_RE.test(raw)) return null;
+  return raw;
 }
 
 function sanitizeList(list: LocationData[]): LocationData[] {


### PR DESCRIPTION
## Summary
- validate station IDs before saving or rendering locations
- avoid storing bad station data in history and current location
- show clear errors when station IDs are invalid

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687669a1d128832db7823a3beddd2a77