### PR TITLE
Improve NOAA request validation

### DIFF
--- a/src/hooks/useTideData.tsx
+++ b/src/hooks/useTideData.tsx
@@ -110,7 +110,8 @@ export const useTideData = ({ location, station }: UseTideDataParams): UseTideDa
 
       try {
         const chosen = station;
-        if (!chosen?.id) {
+        if (!chosen?.id || !/^\d+$/.test(chosen.id)) {
+          setError('Invalid station selected');
           setStationId(null);
           setIsLoading(false);
           return;

--- a/src/services/tide/realStationService.ts
+++ b/src/services/tide/realStationService.ts
@@ -107,6 +107,10 @@ export function getDistanceKm(lat1: number, lng1: number, lat2: number, lng2: nu
 }
 
 export async function findNearestRealStation(lat: number, lng: number): Promise<NoaaStationMetadata | null> {
+  if (!Number.isFinite(lat) || !Number.isFinite(lng)) {
+    console.error('Invalid coordinates for nearest station lookup', { lat, lng });
+    return null;
+  }
   try {
     const stations = await fetchRealStationMetadata();
     

--- a/src/services/tideDataService.ts
+++ b/src/services/tideDataService.ts
@@ -6,6 +6,15 @@
 const NOAA_DATA_BASE = 'https://api.tidesandcurrents.noaa.gov/api/prod/datagetter';
 import { debugLog } from '@/utils/debugLogger';
 
+/* ---------- validation helpers ---------- */
+
+const isValidStationId = (id: string | null | undefined) =>
+  typeof id === 'string' && /^\d+$/.test(id.trim());
+
+const isValidIsoDate = (iso: string | null | undefined) =>
+  typeof iso === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(iso) &&
+  !Number.isNaN(new Date(iso).getTime());
+
 export interface Prediction {
   timeIso: string;
   valueFt: number;
@@ -15,9 +24,12 @@ export interface Prediction {
 export async function getTideData(
   stationId: string,
   dateIso: string
-): Promise<Prediction[]> {
-  const yyyymmdd = dateIso.replace(/-/g, '');
-  if (!stationId || yyyymmdd.length !== 8) {
+  ): Promise<Prediction[]> {
+  if (!isValidStationId(stationId) || !isValidIsoDate(dateIso)) {
+    console.error('❌ Invalid parameters for tide data request', {
+      stationId,
+      dateIso,
+    });
     throw new Error('Invalid parameters for tide data request');
   }
 


### PR DESCRIPTION
## Summary
- add station/date validation utilities to `tideService`
- ensure `tideDataService` checks stationId and dates before fetching
- guard API calls in `useTideData` against invalid station ids
- validate inputs in station services and nearest station helper

## Testing
- `npm run lint`
- `npm run test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687671db5564832daa4b345dcff2aa4b