### PR TITLE
Enhance location metadata usage

### DIFF
--- a/src/components/SavedLocationsList.tsx
+++ b/src/components/SavedLocationsList.tsx
@@ -13,7 +13,14 @@ import { LocationData } from '@/types/locationTypes';
 import type { SavedLocation } from './LocationSelector';
 import { toast } from 'sonner';
 import { fetchRealStationMetadata } from '@/services/tide/realStationService';
-import { normalizeState } from '@/utils/stateNames';
+
+interface StationMetadata {
+  id: string;
+  name: string;
+  lat: number;
+  lng: number;
+  state?: string;
+}
 
 interface SavedLocationsListProps {
   onLocationSelect: (location: LocationData) => void;
@@ -24,22 +31,23 @@ export default function SavedLocationsList({ onLocationSelect, showEmpty = false
   const [locationHistory, setLocationHistory] = useState(locationStorage.getLocationHistory());
   const [deletingLocation, setDeletingLocation] = useState<LocationData | null>(null);
   const { currentLocation, setCurrentLocation, setSelectedStation } = useLocationState();
-  const [stationStates, setStationStates] = useState<Record<string, string>>({});
+  const [stationMetadata, setStationMetadata] = useState<Map<string, StationMetadata>>(new Map());
 
   useEffect(() => {
-    fetchRealStationMetadata()
-      .then((list) => {
-        const map: Record<string, string> = {};
-        list.forEach((s) => {
-          if (s.id && s.state) {
-            map[s.id] = s.state;
-          }
+    const loadStationMetadata = async () => {
+      try {
+        const metadata = await fetchRealStationMetadata();
+        const metadataMap = new Map<string, StationMetadata>();
+        metadata.forEach((station) => {
+          metadataMap.set(station.id, station);
         });
-        setStationStates(map);
-      })
-      .catch((err) => {
-        console.error('Failed to load station metadata', err);
-      });
+        setStationMetadata(metadataMap);
+      } catch (error) {
+        console.warn('Failed to load station metadata:', error);
+      }
+    };
+
+    loadStationMetadata();
   }, []);
 
   useEffect(() => {
@@ -134,31 +142,38 @@ export default function SavedLocationsList({ onLocationSelect, showEmpty = false
 
   const getLocationDisplayName = (location: LocationData | null): string => {
     if (!location) return 'Unknown Location';
-    return (
-      location.stationName ||
-      location.nickname ||
-      (location.city || location.state ? `${location.city}, ${location.state}` : '') ||
-      location.stationId ||
-      'Unknown'
-    );
+
+    const metadata = location.stationId ? stationMetadata.get(location.stationId) : null;
+
+    if (location.nickname) return location.nickname;
+    if (metadata?.name) return metadata.name;
+    return `${location.city}, ${location.state}`;
   };
 
   const getLocationSubtext = (location: LocationData): string => {
-    const id = location.stationId || 'Unknown';
-    const lat = location.lat != null ? location.lat : 'Unknown';
-    const lng = location.lng != null ? location.lng : 'Unknown';
+    const metadata = location.stationId ? stationMetadata.get(location.stationId) : null;
 
-    let state = location.state?.trim();
-    if (!state && id !== 'Unknown') {
-      state = stationStates[id];
+    let subtext = '';
+    if (location.zipCode) {
+      subtext = `ZIP: ${location.zipCode}`;
+    } else {
+      const displayState = metadata?.state || location.state || 'Unknown';
+      subtext = `${location.city}, ${displayState}`;
     }
 
-    let displayState = 'Unknown';
-    if (state) {
-      displayState = normalizeState(state) || state;
+    if (location.stationId) {
+      subtext += ` \u2022 Station: ${location.stationId}`;
     }
 
-    return `${displayState} - ${id} (${lat}, ${lng})`;
+    if (location.lat && location.lng) {
+      subtext += ` \u2022 ${location.lat.toFixed(3)}, ${location.lng.toFixed(3)}`;
+    }
+
+    if (location.isManual) {
+      subtext += ' \u2022 Manual';
+    }
+
+    return subtext;
   };
 
   if (!currentLocData && filteredHistory.length === 0 && showEmpty) {


### PR DESCRIPTION
## Summary
- load complete station metadata for location list
- enrich location display text with metadata

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6876802d328c832d921f0e27d00c01c7