### PR TITLE
Fix metadata load and add logging

### DIFF
--- a/src/components/SavedLocationsList.tsx
+++ b/src/components/SavedLocationsList.tsx
@@ -151,14 +151,15 @@ export default function SavedLocationsList({ onLocationSelect, showEmpty = false
     const lat = location.lat != null ? location.lat : 'Unknown';
     const lng = location.lng != null ? location.lng : 'Unknown';
 
-    let displayState = 'Loading...';
-    if (metadataReady) {
-      let state = location.state?.trim();
-      if (!state && id !== 'Unknown') {
-        state = stationStates[id];
-      }
-      displayState = state ? (normalizeState(state) || state) : 'Unknown';
+    if (!metadataReady) {
+      return `Loading... - ${id} (${lat}, ${lng})`;
     }
+
+    let state = location.state?.trim();
+    if (!state && id !== 'Unknown') {
+      state = stationStates[id];
+    }
+    const displayState = state ? (normalizeState(state) || state) : 'Unknown';
 
     return `${displayState} - ${id} (${lat}, ${lng})`;
   };


### PR DESCRIPTION
## Summary
- update station metadata fetch logic to handle missing `type` field
- add verbose logging for each fetch/parse step
- show `Loading...` instead of unknown state until metadata ready

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68768aa6dafc832d8b09c7f0ce005cda