### PR TITLE
Store user-chosen state with stations

### DIFF
--- a/src/components/LocationManager.tsx
+++ b/src/components/LocationManager.tsx
@@ -11,9 +11,10 @@ import type { Station } from "@/services/tide/stationService";
 interface LocationManagerProps {
   setCurrentLocation: (location: SavedLocation & { id: string; country: string } | null) => void;
   setShowLocationSelector: (show: boolean) => void;
+  selectedState?: string;
 }
 
-const LocationManager = ({ setCurrentLocation, setShowLocationSelector }: LocationManagerProps) => {
+const LocationManager = ({ setCurrentLocation, setShowLocationSelector, selectedState }: LocationManagerProps) => {
   const handleLocationChange = (location: SavedLocation) => {
     console.log('🔄 LocationManager: Location change requested:', location);
     if (!location.id || !NUMERIC_ID_RE.test(location.id)) {
@@ -48,9 +49,9 @@ const LocationManager = ({ setCurrentLocation, setShowLocationSelector }: Locati
       toast.error('Invalid station ID');
       return;
     }
-    const normalized = normalizeStation(station);
+    const normalized = normalizeStation({ ...station, state: selectedState ?? station.state });
     try {
-      persistStationCurrentLocation(normalized);
+      persistStationCurrentLocation(normalized, selectedState);
       saveStationHistory(normalized);
       console.log('💾 LocationManager: Station saved successfully');
     } catch (error) {

--- a/src/hooks/useLocationState.tsx
+++ b/src/hooks/useLocationState.tsx
@@ -29,6 +29,7 @@ function getInitialStation(): Station | null {
 const useLocationStateValue = () => {
   const [currentLocation, setCurrentLocation] = useState(() => getInitialLocation());
   const [selectedStation, setSelectedStation] = useState<Station | null>(() => getInitialStation());
+  const [selectedState, setSelectedState] = useState<string>('');
   const [showLocationSelector, setShowLocationSelector] = useState(!getInitialLocation() && !getInitialStation());
 
   const routerLocation = useRouterLocation();
@@ -68,13 +69,13 @@ const useLocationStateValue = () => {
           name: station.name,
           country: 'USA',
           zipCode: '',
-          cityState: station.city ? `${station.city}, ${station.state}` : '',
+          cityState: station.city ? `${station.city}, ${selectedState || station.state || ''}` : '',
           lat: station.latitude,
           lng: station.longitude
         }),
         id: station.id,
         name: station.name,
-        cityState: station.city ? `${station.city}, ${station.state}` : currentLocation?.cityState ?? '',
+        cityState: station.city ? `${station.city}, ${selectedState || station.state || ''}` : currentLocation?.cityState ?? '',
         lat:
           currentLocation?.zipCode
             ? currentLocation.lat ?? station.latitude
@@ -90,7 +91,7 @@ const useLocationStateValue = () => {
       setShowLocationSelector(false);
     }
     try {
-      safeLocalStorage.set(CURRENT_STATION_KEY, station);
+      safeLocalStorage.set(CURRENT_STATION_KEY, station ? { ...station, state: selectedState || station.state } : null);
     } catch (err) {
       console.warn('Error saving station:', err);
     }
@@ -115,6 +116,8 @@ const useLocationStateValue = () => {
     setCurrentLocation: setCurrentLocationWithPersist,
     showLocationSelector,
     setShowLocationSelector,
+    selectedState,
+    setSelectedState,
     selectedStation,
     setSelectedStation: setSelectedStationWithPersist,
   };

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -22,6 +22,7 @@ const Index = () => {
     setCurrentLocation,
     showLocationSelector,
     setShowLocationSelector,
+    selectedState,
     selectedStation,
     setSelectedStation
   } = useLocationState();
@@ -35,7 +36,7 @@ const Index = () => {
     handleLocationChange,
     handleLocationClear,
     handleGetStarted,
-  } = LocationManager({ setCurrentLocation, setShowLocationSelector });
+  } = LocationManager({ setCurrentLocation, setShowLocationSelector, selectedState });
 
   const [availableStations, setAvailableStations] = useState<Station[]>([]);
   const [showStationPicker, setShowStationPicker] = useState(false);

--- a/src/pages/LocationOnboardingStep1.tsx
+++ b/src/pages/LocationOnboardingStep1.tsx
@@ -51,7 +51,6 @@ interface LocationOnboardingStep1Props {
 }
 
 const LocationOnboardingStep1 = ({ onStationSelect }: LocationOnboardingStep1Props) => {
-  const [selectedState, setSelectedState] = useState('');
   const [stations, setStations] = useState<RawStation[]>([]);
   const [favoriteStates, setFavoriteStates] = useState<string[]>([]);
   const [search, setSearch] = useState('');
@@ -61,7 +60,7 @@ const LocationOnboardingStep1 = ({ onStationSelect }: LocationOnboardingStep1Pro
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const { setSelectedStation: saveStation, setCurrentLocation } = useLocationState();
+  const { setSelectedStation: saveStation, setCurrentLocation, selectedState, setSelectedState } = useLocationState();
   const navigate = useNavigate();
 
   const goToTideScreen = () => {
@@ -131,7 +130,7 @@ const LocationOnboardingStep1 = ({ onStationSelect }: LocationOnboardingStep1Pro
       name: selectedStation.name,
       latitude: parseFloat(String(selectedStation.lat)),
       longitude: parseFloat(String(selectedStation.lng)),
-      state: selectedStation.state,
+      state: selectedState,
       city: selectedStation.city,
     };
 
@@ -146,7 +145,7 @@ const LocationOnboardingStep1 = ({ onStationSelect }: LocationOnboardingStep1Pro
           name: station.name,
           country: 'USA',
           zipCode: solarZip.trim(),
-          cityState: `${geo.places[0]['place name']}, ${geo.places[0].state}`,
+          cityState: `${geo.places[0]['place name']}, ${selectedState}`,
           lat: parseFloat(geo.places[0].latitude),
           lng: parseFloat(geo.places[0].longitude)
         };
@@ -156,7 +155,7 @@ const LocationOnboardingStep1 = ({ onStationSelect }: LocationOnboardingStep1Pro
           name: station.name,
           country: 'USA',
           zipCode: solarZip.trim(),
-          cityState: '',
+          cityState: `, ${selectedState}`,
           lat: null,
           lng: null
         };

--- a/src/utils/currentLocation.ts
+++ b/src/utils/currentLocation.ts
@@ -10,7 +10,7 @@ const NUMERIC_ID_RE = /^\d+$/;
 
 const CURRENT_LOCATION_KEY = 'currentLocation';
 
-export function persistStationCurrentLocation(station?: Station | null) {
+export function persistStationCurrentLocation(station?: Station | null, userState?: string | null) {
   if (!station) {
     console.error('Station object is undefined, not saving.');
     return;
@@ -22,10 +22,11 @@ export function persistStationCurrentLocation(station?: Station | null) {
   const stationObject = station;
   console.log('💾 Saving fetched station object:', stationObject);
   console.log('Saving station currentLocation to storage:', station);
+  const finalState = userState ?? station.state ?? '';
   const storageObj = {
     stationId: station.id,
     stationName: station.name,
-    state: station.state ?? '',
+    state: finalState,
     lat: station.latitude,
     lng: station.longitude,
     zipCode: station.zip ?? '',
@@ -39,7 +40,7 @@ export function persistStationCurrentLocation(station?: Station | null) {
   const locationData: LocationData = {
     zipCode: station.zip ?? '',
     city: station.city ?? station.name,
-    state: station.state ?? '',
+    state: finalState,
     lat: station.latitude,
     lng: station.longitude,
     stationId: station.id,
@@ -56,13 +57,13 @@ export function persistStationCurrentLocation(station?: Station | null) {
     lat: station.latitude,
     lng: station.longitude,
     city: station.city ?? '',
-    state: station.state ?? '',
+    state: finalState,
     zipCode: station.zip ?? '',
     sourceType: 'station',
     timestamp: Date.now(),
   };
   saveLocationHistory(entry);
-  saveStationHistory(station);
+  saveStationHistory({ ...station, state: finalState });
 }
 
 export function persistCurrentLocation(location: SavedLocation & { id: string; country: string }) {


### PR DESCRIPTION
## Summary
- add selectedState to location context
- persist selectedState on onboarding
- save selectedState when storing station info
- pass selectedState to LocationManager and persistence helpers

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68769c4b6f18832db0b29fb5c3aa32f4