### PR TITLE
Support user-selected state across location flow

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
     "preview": "vite preview",
-    "android:debug": "npm run build && npx cap sync android && cd android && ./gradlew assembleDebug"
+    "android:debug": "npm run build && npx cap sync android && cd android && ./gradlew assembleDebug",
+    "test": "vitest"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",
@@ -81,6 +82,8 @@
     "tailwindcss": "^3.4.11",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.0.1",
-    "vite": "^5.4.1"
+    "vite": "^5.4.1",
+    "vitest": "^1.5.0",
+    "@testing-library/react": "^14.1.2"
   }
 }

--- a/src/components/LocationSelector.tsx
+++ b/src/components/LocationSelector.tsx
@@ -18,6 +18,7 @@ export interface SavedLocation {
   cityState: string;
   lat: number | null;
   lng: number | null;
+  userSelectedState?: string;
 }
 
 export default function LocationSelector({
@@ -70,7 +71,8 @@ export default function LocationSelector({
       zipCode: location.zipCode,
       cityState: `${location.city}, ${location.state}`,
       lat: location.lat ?? null,
-      lng: location.lng ?? null
+      lng: location.lng ?? null,
+      userSelectedState: location.userSelectedState
     };
 
     onSelect(savedLocation);
@@ -82,7 +84,8 @@ export default function LocationSelector({
         latitude: location.lat ?? 0,
         longitude: location.lng ?? 0,
         state: location.state,
-        city: location.city
+        city: location.city,
+        userSelectedState: location.userSelectedState
       };
       onStationSelect(station);
     }

--- a/src/components/SavedLocationsList.tsx
+++ b/src/components/SavedLocationsList.tsx
@@ -13,7 +13,7 @@ import { LocationData } from '@/types/locationTypes';
 import type { SavedLocation } from './LocationSelector';
 import { toast } from 'sonner';
 import { metadataManager } from '@/services/tide/metadataManager';
-import { normalizeState } from '@/utils/stateNames';
+import { formatLocationSubtext } from '@/utils/locationFormatting';
 
 interface SavedLocationsListProps {
   onLocationSelect: (location: LocationData) => void;
@@ -98,6 +98,7 @@ export default function SavedLocationsList({ onLocationSelect, showEmpty = false
       zipCode: loc.zipCode,
       city: city || '',
       state: state || '',
+      userSelectedState: loc.userSelectedState,
       lat: loc.lat,
       lng: loc.lng,
       stationId: loc.id,
@@ -147,21 +148,13 @@ export default function SavedLocationsList({ onLocationSelect, showEmpty = false
   };
 
   const getLocationSubtext = (location: LocationData): string => {
-    const id = location.stationId || 'Unknown';
-    const lat = location.lat != null ? location.lat : 'Unknown';
-    const lng = location.lng != null ? location.lng : 'Unknown';
-
     if (!metadataReady) {
+      const id = location.stationId || 'Unknown';
+      const lat = location.lat != null ? location.lat : 'Unknown';
+      const lng = location.lng != null ? location.lng : 'Unknown';
       return `Loading... - ${id} (${lat}, ${lng})`;
     }
-
-    let state = location.state?.trim();
-    if (!state && id !== 'Unknown') {
-      state = stationStates[id];
-    }
-    const displayState = state ? (normalizeState(state) || state) : 'Unknown';
-
-    return `${displayState} - ${id} (${lat}, ${lng})`;
+    return formatLocationSubtext(location, stationStates);
   };
 
   if (!currentLocData && filteredHistory.length === 0 && showEmpty) {

--- a/src/hooks/useLocationState.tsx
+++ b/src/hooks/useLocationState.tsx
@@ -20,7 +20,9 @@ function getInitialLocation(): (SavedLocation & { id: string; country: string })
 function getInitialStation(): Station | null {
   try {
     const saved = safeLocalStorage.get(CURRENT_STATION_KEY);
-    return saved?.id && NUMERIC_ID_RE.test(String(saved.id)) ? (saved as Station) : null;
+    return saved?.id && NUMERIC_ID_RE.test(String(saved.id))
+      ? (saved as Station)
+      : null;
   } catch {
     return null;
   }
@@ -76,6 +78,7 @@ const useLocationStateValue = () => {
         id: station.id,
         name: station.name,
         cityState: station.city ? `${station.city}, ${selectedState || station.state || ''}` : currentLocation?.cityState ?? '',
+        userSelectedState: selectedState || station.userSelectedState,
         lat:
           currentLocation?.zipCode
             ? currentLocation.lat ?? station.latitude
@@ -91,7 +94,12 @@ const useLocationStateValue = () => {
       setShowLocationSelector(false);
     }
     try {
-      safeLocalStorage.set(CURRENT_STATION_KEY, station ? { ...station, state: selectedState || station.state } : null);
+      safeLocalStorage.set(
+        CURRENT_STATION_KEY,
+        station
+          ? { ...station, state: selectedState || station.state, userSelectedState: selectedState || station.userSelectedState }
+          : null,
+      );
     } catch (err) {
       console.warn('Error saving station:', err);
     }

--- a/src/pages/LocationOnboardingStep1.tsx
+++ b/src/pages/LocationOnboardingStep1.tsx
@@ -132,6 +132,7 @@ const LocationOnboardingStep1 = ({ onStationSelect }: LocationOnboardingStep1Pro
       longitude: parseFloat(String(selectedStation.lng)),
       state: selectedState,
       city: selectedStation.city,
+      userSelectedState: selectedState,
     };
 
     // Precompute the location object so we can persist it after selecting the station
@@ -147,7 +148,8 @@ const LocationOnboardingStep1 = ({ onStationSelect }: LocationOnboardingStep1Pro
           zipCode: solarZip.trim(),
           cityState: `${geo.places[0]['place name']}, ${selectedState}`,
           lat: parseFloat(geo.places[0].latitude),
-          lng: parseFloat(geo.places[0].longitude)
+          lng: parseFloat(geo.places[0].longitude),
+          userSelectedState: selectedState,
         };
       } else {
         newLocation = {
@@ -157,7 +159,8 @@ const LocationOnboardingStep1 = ({ onStationSelect }: LocationOnboardingStep1Pro
           zipCode: solarZip.trim(),
           cityState: `, ${selectedState}`,
           lat: null,
-          lng: null
+          lng: null,
+          userSelectedState: selectedState,
         };
       }
     }

--- a/src/services/storage/locationHistory.ts
+++ b/src/services/storage/locationHistory.ts
@@ -31,6 +31,7 @@ export interface SavedLocation {
   lng        : number;
   city?      : string;
   state?     : string;
+  userSelectedState?: string;
   zipCode?   : string;
   sourceType : 'station';
   timestamp  : number;
@@ -57,6 +58,7 @@ export function normalizeStation(
     lng        : Number(record.lng ?? record.longitude),
     city       : record.city  ?? '',
     state      : record.state ?? '',
+    userSelectedState: (record as any).userSelectedState ?? '',
     zipCode    : record.zipCode ?? '',
     sourceType : 'station',
     timestamp  : Date.now(),

--- a/src/services/tide/stationService.ts
+++ b/src/services/tide/stationService.ts
@@ -16,6 +16,7 @@ export interface Station {
   zip?: string;
   city?: string;
   state?: string;
+  userSelectedState?: string;
   distance?: number;
 }
 

--- a/src/types/locationHistory.ts
+++ b/src/types/locationHistory.ts
@@ -6,6 +6,7 @@ export interface LocationHistoryEntry {
   lng: number;
   city?: string;
   state?: string;
+  userSelectedState?: string;
   zipCode?: string;
   sourceType: 'zip' | 'text' | 'gps' | 'station';
   searchQuery?: string;

--- a/src/types/locationTypes.ts
+++ b/src/types/locationTypes.ts
@@ -3,6 +3,7 @@ export interface LocationData {
   zipCode: string;
   city: string;
   state: string;
+  userSelectedState?: string;
   lat: number | null;
   lng: number | null;
   stationId?: string;

--- a/src/utils/currentLocation.ts
+++ b/src/utils/currentLocation.ts
@@ -27,6 +27,7 @@ export function persistStationCurrentLocation(station?: Station | null, userStat
     stationId: station.id,
     stationName: station.name,
     state: finalState,
+    userSelectedState: userState ?? station.userSelectedState ?? '',
     lat: station.latitude,
     lng: station.longitude,
     zipCode: station.zip ?? '',
@@ -41,6 +42,7 @@ export function persistStationCurrentLocation(station?: Station | null, userStat
     zipCode: station.zip ?? '',
     city: station.city ?? station.name,
     state: finalState,
+    userSelectedState: userState ?? station.userSelectedState ?? '',
     lat: station.latitude,
     lng: station.longitude,
     stationId: station.id,
@@ -58,6 +60,7 @@ export function persistStationCurrentLocation(station?: Station | null, userStat
     lng: station.longitude,
     city: station.city ?? '',
     state: finalState,
+    userSelectedState: userState ?? station.userSelectedState ?? '',
     zipCode: station.zip ?? '',
     sourceType: 'station',
     timestamp: Date.now(),
@@ -77,6 +80,7 @@ export function persistCurrentLocation(location: SavedLocation & { id: string; c
     zipCode: location.zipCode || '',
     city: city || location.name,
     state: state || '',
+    userSelectedState: location.userSelectedState ?? state || '',
     lat: location.lat,
     lng: location.lng,
     stationId: isStationId ? location.id : undefined,
@@ -93,6 +97,7 @@ export function persistCurrentLocation(location: SavedLocation & { id: string; c
     zipCode: location.zipCode,
     city: city || location.name,
     state: state || '',
+    userSelectedState: location.userSelectedState ?? state || '',
     lat: location.lat,
     lng: location.lng,
     stationId: storageObj.stationId,
@@ -110,6 +115,7 @@ export function persistCurrentLocation(location: SavedLocation & { id: string; c
     lng: location.lng,
     city: city || undefined,
     state: state || undefined,
+    userSelectedState: location.userSelectedState ?? state || undefined,
     zipCode: location.zipCode || undefined,
     sourceType: location.zipCode ? 'zip' : 'station',
     timestamp: Date.now(),
@@ -130,6 +136,7 @@ export function loadCurrentLocation(): (SavedLocation & { id: string; country: s
       cityState: `${saved.city}, ${saved.state}`,
       lat: saved.lat ?? null,
       lng: saved.lng ?? null,
+      userSelectedState: saved.userSelectedState,
     };
   } else if (saved) {
     // remove invalid legacy entry
@@ -146,6 +153,7 @@ export function loadCurrentLocation(): (SavedLocation & { id: string; country: s
       cityState: `${stored.city}, ${stored.state}`,
       lat: stored.lat ?? null,
       lng: stored.lng ?? null,
+      userSelectedState: stored.userSelectedState,
     };
   }
 

--- a/src/utils/locationFormatting.ts
+++ b/src/utils/locationFormatting.ts
@@ -1,0 +1,18 @@
+import { LocationData } from '@/types/locationTypes';
+import { normalizeState } from '@/utils/stateNames';
+
+export function formatLocationSubtext(
+  location: LocationData,
+  stationStates: Record<string, string> = {},
+): string {
+  const id = location.stationId || 'Unknown';
+  const lat = location.lat != null ? location.lat : 'Unknown';
+  const lng = location.lng != null ? location.lng : 'Unknown';
+
+  let state = location.userSelectedState?.trim() || location.state?.trim();
+  if (!state && id !== 'Unknown') {
+    state = stationStates[id];
+  }
+  const displayState = state ? normalizeState(state) || state : 'Unknown';
+  return `${displayState} - ${id} (${lat}, ${lng})`;
+}

--- a/src/utils/locationStorage.ts
+++ b/src/utils/locationStorage.ts
@@ -31,7 +31,12 @@ export const locationStorage = {
       console.error('[locationStorage] invalid stationId, aborting save');
       return;
     }
-    const entry = { ...location, stationId: id, timestamp: Date.now() };
+    const entry = {
+      ...location,
+      stationId: id,
+      timestamp: Date.now(),
+      userSelectedState: location.userSelectedState,
+    };
     safeLocalStorage.set(CURRENT_LOCATION_KEY, entry);
     const history = locationStorage
       .getLocationHistory()
@@ -68,12 +73,20 @@ export const locationStorage = {
     const history = locationStorage.getLocationHistory();
     const idx = history.findIndex(h => h.stationId === id);
     if (idx === -1) return;
-    history[idx] = { ...updated, stationId: id, timestamp: history[idx].timestamp ?? Date.now() };
+    history[idx] = {
+      ...updated,
+      stationId: id,
+      timestamp: history[idx].timestamp ?? Date.now(),
+    };
     safeLocalStorage.set(LOCATION_HISTORY_KEY, history);
 
     const current = locationStorage.getCurrentLocation();
     if (current && current.stationId === id) {
-      safeLocalStorage.set(CURRENT_LOCATION_KEY, { ...updated, stationId: id, timestamp: current.timestamp });
+      safeLocalStorage.set(CURRENT_LOCATION_KEY, {
+        ...updated,
+        stationId: id,
+        timestamp: current.timestamp,
+      });
     }
   },
 

--- a/tests/locationDisplay.test.ts
+++ b/tests/locationDisplay.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { formatLocationSubtext } from '../src/utils/locationFormatting';
+import { LocationData } from '../src/types/locationTypes';
+
+describe('formatLocationSubtext', () => {
+  it('prefers userSelectedState over NOAA state', () => {
+    const location: LocationData = {
+      zipCode: '00000',
+      city: 'Test',
+      state: 'XX',
+      userSelectedState: 'YY',
+      lat: 1,
+      lng: 2,
+      stationId: '123',
+      stationName: 'Station',
+      isManual: false,
+    };
+    const stationStates: Record<string, string> = { '123': 'ZZ' };
+    const result = formatLocationSubtext(location, stationStates);
+    expect(result.startsWith('YY')).toBe(true);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react-swc';
+import path from 'path';
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: 'jsdom',
+    globals: true,
+  },
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- add `userSelectedState` field to location and station types
- store and persist the user-selected state when choosing a station
- update location storage, history, and current location utilities
- show the user's chosen state in saved location listings
- extract formatting helper for location subtext
- add vitest config and unit test for state display

## Testing
- `npx vitest run` *(fails: 403 Forbidden)*
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876aca4fe54832d8cfd2fa6932bacb6