### PR TITLE
Improve moon phase display

### DIFF
--- a/src/components/MoonData.tsx
+++ b/src/components/MoonData.tsx
@@ -52,22 +52,22 @@ const MoonData = ({ illumination, moonrise, moonset }: MoonDataProps) => {
   );
 
   return (
-    <div className="grid grid-cols-2 gap-4 w-full">
-      <div className="text-center">
-        <p className="text-muted-foreground text-sm">Illumination</p>
-        <p className="text-lg font-semibold text-moon-primary">{illumination}%</p>
+    <div className="w-full text-sm divide-y divide-muted/30">
+      <div className="flex items-center justify-between py-1">
+        <span className="text-muted-foreground">Illumination</span>
+        <span className="font-semibold text-moon-primary">{illumination}%</span>
       </div>
-      <div className="text-center">
-        <p className="text-muted-foreground text-sm">Moonrise</p>
-        <p className="text-lg font-semibold">{formatTimeToAmPm(moonrise)}</p>
+      <div className="flex items-center justify-between py-1">
+        <span className="text-muted-foreground">Moonrise</span>
+        <span className="font-semibold">{formatTimeToAmPm(moonrise)}</span>
       </div>
-      <div className="text-center">
-        <p className="text-muted-foreground text-sm">Moonset</p>
-        <p className="text-lg font-semibold">{formatTimeToAmPm(moonset)}</p>
+      <div className="flex items-center justify-between py-1">
+        <span className="text-muted-foreground">Moonset</span>
+        <span className="font-semibold">{formatTimeToAmPm(moonset)}</span>
       </div>
-      <div className="text-center">
-        <p className="text-muted-foreground text-sm">Next Phase</p>
-        <p className="text-lg font-semibold">{nextPhaseInfo}</p>
+      <div className="flex items-center justify-between py-1">
+        <span className="text-muted-foreground">Next Phase</span>
+        <span className="font-semibold">{nextPhaseInfo}</span>
       </div>
     </div>
   );

--- a/src/components/MoonPhase.tsx
+++ b/src/components/MoonPhase.tsx
@@ -78,17 +78,15 @@ const MoonPhase = ({
   return (
     <div className="w-full">
       <Card className={cn("overflow-hidden bg-card/50 backdrop-blur-md", className)}>
-        <CardHeader>
-          <CardTitle className="flex flex-col items-center space-y-1">
-            <span className="whitespace-nowrap text-base font-semibold sm:text-lg">{actualPhase}</span>
-            {fullMoonName && (
-              <FullMoonBanner fullMoonName={fullMoonName} />
-            )}
-            <span className="text-moon-primary text-sm whitespace-nowrap sm:text-base">{date}</span>
-          </CardTitle>
-        </CardHeader>
-        <CardContent className="flex flex-col items-center space-y-6">
+        <CardHeader className="flex flex-col items-center space-y-2 py-4">
           <MoonVisual phase={actualPhase} illumination={actualIllumination} />
+          <CardTitle className="text-center text-lg sm:text-2xl font-bold bg-gradient-to-r from-moon-primary to-moon-blue bg-clip-text text-transparent">
+            {actualPhase}
+          </CardTitle>
+          {fullMoonName && <FullMoonBanner fullMoonName={fullMoonName} />}
+          <p className="text-sm text-muted-foreground -mt-1">{date}</p>
+        </CardHeader>
+        <CardContent className="flex flex-col items-center space-y-4">
 
           <MoonData
             illumination={actualIllumination}

--- a/src/components/MoonVisual.tsx
+++ b/src/components/MoonVisual.tsx
@@ -32,7 +32,9 @@ const MoonVisual = ({ phase, illumination }: MoonVisualProps) => {
 
   return (
     <div className="relative">
-      <div className={`w-36 h-36 rounded-full animate-pulse shadow-lg ${getMoonPhaseVisual()}`}></div>
+      <div
+        className={`w-36 h-36 rounded-full animate-pulse shadow-lg shadow-moon-primary/40 ${getMoonPhaseVisual()}`}
+      ></div>
       <div className="absolute bottom-0 left-1/2 transform -translate-x-1/2 translate-y-8 bg-gradient-to-t from-moon-primary/20 to-transparent w-24 h-12 blur-md rounded-full"></div>
     </div>
   );


### PR DESCRIPTION
## Summary
- tweak MoonVisual glow
- show moon image in card header
- restyle MoonData in single vertical block
- adjust splash layout for better spacing

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68777d8c75bc832da975509e26a8210f