### PR TITLE
Refine header icon alignment

### DIFF
--- a/src/components/AppHeader.tsx
+++ b/src/components/AppHeader.tsx
@@ -31,14 +31,14 @@ export default function AppHeader({
         </div>
         <div className="flex items-center justify-evenly py-1 w-full">
           <Link to="/fishing-calendar" className="flex flex-col items-center w-20 gap-1">
-            <Button variant="ghost" size="icon" className="h-6 w-6 p-0">
-              <Calendar className="h-6 w-6" />
+            <Button variant="ghost" size="icon" className="h-5 w-5 p-0">
+              <Calendar className="h-5 w-5" />
             </Button>
             <div className="text-xs text-gray-400 text-center">Moon Calendar</div>
           </Link>
           <Link to="/settings" className="flex flex-col items-center w-20 gap-1">
-            <Button variant="ghost" size="icon" className="h-6 w-6 p-0">
-              <Settings className="h-6 w-6" />
+            <Button variant="ghost" size="icon" className="h-5 w-5 p-0">
+              <Settings className="h-5 w-5" />
             </Button>
             <div className="text-xs text-gray-400 text-center">Settings</div>
           </Link>
@@ -47,10 +47,11 @@ export default function AppHeader({
             onStationSelect={onStationSelect}
             forceOpen={forceShowLocationSelector}
             onClose={onLocationSelectorClose}
+            buttonClassName="p-0"
             triggerContent={
               <div className="flex flex-col items-center w-20 gap-1">
-                <Button variant="ghost" size="icon" className="h-6 w-6 p-0">
-                  <MapPin className="h-6 w-6" />
+                <Button variant="ghost" size="icon" className="h-5 w-5 p-0">
+                  <MapPin className="h-5 w-5" />
                 </Button>
                 <div className="text-xs text-gray-400 text-center">Change Tides</div>
               </div>

--- a/src/components/LocationSelector.tsx
+++ b/src/components/LocationSelector.tsx
@@ -3,6 +3,7 @@ import React, { useState, useEffect } from 'react';
 import { MapPin, Plus } from 'lucide-react';
 import { DropdownMenu, DropdownMenuTrigger, DropdownMenuContent } from '@/components/ui/dropdown-menu';
 import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
 import { LocationData } from '@/types/locationTypes';
 import SavedLocationsList from './SavedLocationsList';
 import { Station } from '@/services/tide/stationService';
@@ -27,7 +28,8 @@ export default function LocationSelector({
   forceOpen,
   onClose,
   onStationSelect,
-  triggerContent
+  triggerContent,
+  buttonClassName
 }: {
   onSelect: (loc: SavedLocation) => void;
   onLocationClear?: () => void;
@@ -35,6 +37,7 @@ export default function LocationSelector({
   onClose?: () => void;
   onStationSelect?: (station: Station) => void;
   triggerContent?: React.ReactNode;
+  buttonClassName?: string;
 }) {
   const [isOpen, setIsOpen] = useState(false);
 
@@ -100,7 +103,12 @@ export default function LocationSelector({
   return (
     <DropdownMenu open={isOpen} onOpenChange={handleOpenChange}>
       <DropdownMenuTrigger asChild>
-        <button className="flex items-center gap-1 px-3 py-2 text-sm font-medium">
+        <button
+          className={cn(
+            "flex items-center gap-1",
+            buttonClassName ? buttonClassName : "px-3 py-2 text-sm font-medium"
+          )}
+        >
           {triggerContent ?? (
             <>
               <MapPin size={16} />


### PR DESCRIPTION
## Summary
- add optional `buttonClassName` to `LocationSelector`
- shrink icon buttons in `AppHeader`
- remove extra padding on the `LocationSelector` trigger for consistent alignment

## Testing
- `npm test` *(fails: vitest not found)*
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_68778dd42138832d9dc40e4f6d8b96b3