### PR TITLE
Fix solstice delta display

### DIFF
--- a/src/components/MoonPhase.tsx
+++ b/src/components/MoonPhase.tsx
@@ -2,11 +2,11 @@ import React from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { cn } from "@/lib/utils";
 import { getFullMoonName, isFullMoon, calculateMoonPhase } from '@/utils/lunarUtils';
-import { calculateSolarTimes, getSolarEvents } from '@/utils/solarUtils';
+import { getSolarEvents } from '@/utils/solarUtils';
 import FullMoonBanner from './FullMoonBanner';
 import MoonVisual from './MoonVisual';
 import MoonData from './MoonData';
-import SolarInfo from './SolarInfo';
+import SunCard from './SunCard';
 import SolarEventInfo from './fishing/SolarEventInfo';
 import { LocationData } from '@/types/locationTypes';
 import { SavedLocation } from './LocationSelector';
@@ -68,11 +68,6 @@ const MoonPhase = ({
   const lat = currentLocation?.lat ?? 41.4353; // Default to Newport, RI
   const lng = currentLocation?.lng ?? -71.4616;
 
-  const solarTimes = React.useMemo(
-    () => calculateSolarTimes(currentDate, lat, lng),
-    [currentDate, lat, lng]
-  );
-
   const solarEvent = getSolarEvents(currentDate);
 
   return (
@@ -95,7 +90,7 @@ const MoonPhase = ({
           />
 
           <div className="border-t border-muted pt-4 w-full space-y-4">
-            <SolarInfo solarTimes={solarTimes} zipCode={currentLocation?.zipCode} />
+            <SunCard lat={lat} lng={lng} date={currentDate} />
             {solarEvent && <SolarEventInfo selectedDate={currentDate} />}
           </div>
         </CardContent>

--- a/src/services/storage/locationHistory.ts
+++ b/src/services/storage/locationHistory.ts
@@ -58,7 +58,7 @@ export function normalizeStation(
     lng        : Number(record.lng ?? record.longitude),
     city       : record.city  ?? '',
     state      : record.state ?? '',
-    userSelectedState: (record as any).userSelectedState ?? '',
+    userSelectedState: record.userSelectedState ?? '',
     zipCode    : record.zipCode ?? '',
     sourceType : 'station',
     timestamp  : Date.now(),


### PR DESCRIPTION
## Summary
- use `SunCard` instead of `SolarInfo` so solstice daylight deltas show
- cleanup leftover solar times calculation
- remove an `any` cast in `locationHistory`

## Testing
- `npm run lint`
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877c2f37210832db444afddad311fe2