### PR TITLE
Improve solstice label responsiveness

### DIFF
--- a/src/components/SunCard.tsx
+++ b/src/components/SunCard.tsx
@@ -21,7 +21,8 @@ const SunCard: React.FC<SunCardProps> = ({ lat, lng, date }) => {
 
   const isSummerWindow = date >= summerSolstice && date < winterSolstice;
   const refLabelDate = isSummerWindow ? 'Jun 21' : 'Dec 21';
-  const refSeason = isSummerWindow ? 'Summer' : 'Winter';
+  const refSeasonFull = isSummerWindow ? 'Summer' : 'Winter';
+  const refSeasonShort = isSummerWindow ? 'Sum.' : 'Win.';
 
   const solsticeDaylightMins = calculateSolarTimes(
     isSummerWindow ? summerSolstice : winterSolstice,
@@ -56,8 +57,11 @@ const SunCard: React.FC<SunCardProps> = ({ lat, lng, date }) => {
         <span className={`font-semibold ${gettingLonger ? 'text-lime-400' : gettingShorter ? 'text-red-400' : 'text-gray-300'}`}>{sunTimes.changeFromPrevious}</span>
       </div>
       <div className="mt-1 text-sm leading-tight">
-        <div className="text-gray-400">
-          Since {refLabelDate} ({refSeason} Solstice)
+        <div className="flex items-center gap-1 whitespace-nowrap text-[0.688rem] sm:text-xs md:text-sm text-gray-400">
+          <span>Since {refLabelDate}</span>
+          {/* xs/sm = short label; md+ = full label */}
+          <span className="md:hidden">({refSeasonShort})</span>
+          <span className="hidden md:inline">({refSeasonFull} Solstice)</span>
         </div>
         <div className={deltaMins < 0 ? 'text-red-400' : 'text-lime-400'}>
           Daylight {formatSignedDuration(deltaMins)}


### PR DESCRIPTION
## Summary
- tweak SunCard solstice reference text to be responsive
- add abbreviated and full season labels

## Testing
- `npm test` *(fails: `vitest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877d212c728832db03206e74272d20c