### PR TITLE
Fix moon phase data on splash page

### DIFF
--- a/src/components/MainContent.tsx
+++ b/src/components/MainContent.tsx
@@ -6,6 +6,7 @@ import { TidePoint, TideForecast } from '@/services/tide/types';
 import { LocationData } from '@/types/locationTypes';
 import { SavedLocation } from './LocationSelector';
 import { formatApiDate } from '@/utils/dateTimeUtils';
+import { calculateMoonPhase } from '@/utils/lunarUtils';
 
 interface MainContentProps {
   error: string | null;
@@ -36,9 +37,11 @@ export default function MainContent({
   banner,
   onGetStarted
 }: MainContentProps) {
+  const { phase, illumination } = calculateMoonPhase(new Date(currentDate));
+
   const moonPhaseData = {
-    phase: weeklyForecast.length > 0 ? weeklyForecast[0].moonPhase : "Waxing Crescent",
-    illumination: weeklyForecast.length > 0 ? weeklyForecast[0].illumination : 35,
+    phase,
+    illumination,
     moonrise: "18:42",
     moonset: "07:15",
     date: formatApiDate(currentDate)


### PR DESCRIPTION
## Summary
- calculate today's moon phase in `MainContent`
- use `calculateMoonPhase` to derive the phase and illumination for the splash page

## Testing
- `npm run lint`
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878000ed174832da3d090b5269840c9