### PR TITLE
Improve moon phase accuracy

### DIFF
--- a/tests/lunarUtils.test.ts
+++ b/tests/lunarUtils.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import { calculateMoonPhase } from '../src/utils/lunarUtils';
+
+// Test a date mid-cycle far from reference to ensure accuracy
+// July 16, 2025 should be Waning Gibbous according to trusted ephemeris
+
+describe('calculateMoonPhase', () => {
+  it('returns Waning Gibbous for July 16, 2025', () => {
+    const date = new Date('2025-07-16T00:00:00Z');
+    const result = calculateMoonPhase(date);
+    expect(result.phase).toBe('Waning Gibbous');
+  });
+
+  it('handles new moon in 2026 without drift', () => {
+    const date = new Date('2026-07-15T00:00:00Z');
+    const result = calculateMoonPhase(date);
+    expect(result.phase).toBe('New Moon');
+  });
+});


### PR DESCRIPTION
## Summary
- calculate moon phase relative to latest ephemeris new moon
- add helper to locate the most recent new moon
- test phase calculation accuracy

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687808573114832da1f74bc1a2d03070