### PR TITLE
Add external links to settings

### DIFF
--- a/src/components/settings/SettingsList.tsx
+++ b/src/components/settings/SettingsList.tsx
@@ -2,17 +2,19 @@
 import React from 'react';
 import SettingsSection from './SettingsSection';
 import SettingsItem from './SettingsItem';
-import { 
-  User, 
-  MapPin, 
-  Bell, 
-  Palette, 
-  Globe, 
-  Shield, 
-  HelpCircle, 
+import {
+  User,
+  MapPin,
+  Bell,
+  Palette,
+  Globe,
+  Shield,
+  HelpCircle,
   Info,
   Star,
-  Share2
+  Share2,
+  FileText,
+  Mail
 } from 'lucide-react';
 
 const SettingsList = () => {
@@ -91,6 +93,24 @@ const SettingsList = () => {
           title="Share App"
           subtitle="Tell friends about MoonTide"
           onClick={() => console.log('Share clicked')}
+        />
+        <SettingsItem
+          icon={FileText}
+          title="Privacy Policy"
+          subtitle="Read how we handle data"
+          onClick={() => window.open('https://moontide.site/privacy', '_blank')}
+        />
+        <SettingsItem
+          icon={FileText}
+          title="Terms of Service"
+          subtitle="Review our terms"
+          onClick={() => window.open('https://moontide.site/terms', '_blank')}
+        />
+        <SettingsItem
+          icon={Mail}
+          title="Send Feedback or Suggestions"
+          subtitle="We'd love to hear from you"
+          onClick={() => window.open('mailto:moontidesite@gmail.com?subject=' + encodeURIComponent('Moontide App Feedback'), '_blank')}
         />
       </SettingsSection>
     </div>

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -1,7 +1,6 @@
 
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
-import { ArrowLeft } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import StarsBackdrop from '@/components/StarsBackdrop';
 import SettingsHeader from '@/components/settings/SettingsHeader';
@@ -23,6 +22,17 @@ const Settings = () => {
         <SettingsHeader onBackPress={handleBackPress} />
         <div className="px-4 mt-6">
           <SettingsList />
+          <div className="mt-12 text-center space-y-2">
+            <p className="text-sm text-gray-400">
+              For more information, detailed instructions, and the latest updates, visit our website.
+            </p>
+            <Button
+              variant="link"
+              onClick={() => window.open('https://moontide.site', '_blank')}
+            >
+              Visit moontide.site
+            </Button>
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- update SettingsList with buttons for Privacy, Terms, and Feedback
- add footer blurb and link to moontide.site on Settings page

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a3d85fb3c832db44da6229e4b0105