### PR TITLE
Fix zip code placement and remove input from SunCard

### DIFF
--- a/src/components/LocationDisplay.tsx
+++ b/src/components/LocationDisplay.tsx
@@ -11,7 +11,7 @@ interface LocationDisplayProps {
   showZipCode?: boolean;
 }
 
-export default function LocationDisplay({ currentLocation, stationName, stationId, hasError, showZipCode = true }: LocationDisplayProps) {
+export default function LocationDisplay({ currentLocation, stationName, stationId, hasError, showZipCode = false }: LocationDisplayProps) {
   const formatLocationDisplay = () => {
     if (!currentLocation) return 'Select a location';
     if (stationName) return stationName;

--- a/src/components/MoonPhase.tsx
+++ b/src/components/MoonPhase.tsx
@@ -91,7 +91,7 @@ const MoonPhase = ({
           />
 
           <div className="border-t border-muted pt-4 w-full space-y-4">
-            <SunCard lat={lat} lng={lng} date={currentDate} />
+            <SunCard lat={lat} lng={lng} date={currentDate} zipCode={currentLocation?.zipCode} />
             {solarEvent && <SolarEventInfo selectedDate={currentDate} />}
           </div>
         </CardContent>

--- a/src/components/SunCard.tsx
+++ b/src/components/SunCard.tsx
@@ -1,24 +1,17 @@
 import React from 'react';
 import { calculateSolarTimes } from '@/utils/solarUtils';
-import { lookupZipCode } from '@/utils/zipCodeLookup';
-import { Input } from '@/components/ui/input';
-import { Button } from '@/components/ui/button';
-import { Loader2 } from 'lucide-react';
 import { formatSignedDuration } from '../utils/time';
 
 interface SunCardProps {
   lat: number;
   lng: number;
   date: Date;
+  zipCode?: string;
 }
 
-const SunCard: React.FC<SunCardProps> = ({ lat, lng, date }) => {
-  const [zip, setZip] = React.useState('');
-  const [coords, setCoords] = React.useState({ lat, lng });
-  const [loading, setLoading] = React.useState(false);
-  const [error, setError] = React.useState<string | null>(null);
+const SunCard: React.FC<SunCardProps> = ({ lat, lng, date, zipCode }) => {
 
-  const sunTimes = React.useMemo(() => calculateSolarTimes(date, coords.lat, coords.lng), [date, coords]);
+  const sunTimes = React.useMemo(() => calculateSolarTimes(date, lat, lng), [date, lat, lng]);
   const todayDaylightMins = sunTimes.daylightMinutes;
 
   const year = date.getFullYear();
@@ -34,53 +27,21 @@ const SunCard: React.FC<SunCardProps> = ({ lat, lng, date }) => {
 
   const solsticeDaylightMins = calculateSolarTimes(
     isSummerWindow ? summerSolstice : winterSolstice,
-    coords.lat,
-    coords.lng
+    lat,
+    lng
   ).daylightMinutes;
   const deltaMins = todayDaylightMins - solsticeDaylightMins;
 
   const gettingLonger = sunTimes.changeFromPrevious?.includes('+');
   const gettingShorter = sunTimes.changeFromPrevious?.includes('-');
 
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    if (!zip.trim() || loading) return;
-    if (!/^\d{5}$/.test(zip.trim())) {
-      setError('Enter valid ZIP');
-      return;
-    }
-    setLoading(true);
-    const res = await lookupZipCode(zip.trim());
-    setLoading(false);
-    if (res && res.places && res.places.length > 0) {
-      setCoords({
-        lat: parseFloat(res.places[0].latitude),
-        lng: parseFloat(res.places[0].longitude),
-      });
-      setError(null);
-    } else {
-      setError('ZIP not found');
-    }
-  };
+  // Display sunrise and sunset for the provided coordinates only
 
   return (
     <div className="flex flex-col gap-y-2 text-sm">
-      <form onSubmit={handleSubmit} className="flex items-center gap-2">
-        <Input
-          value={zip}
-          onChange={(e) => setZip(e.target.value)}
-          placeholder="ZIP"
-          className="h-7 px-2 text-xs"
-        />
-        <Button
-          type="submit"
-          size="sm"
-          disabled={loading || !/^\d{5}$/.test(zip.trim())}
-        >
-          {loading ? <Loader2 className="h-4 w-4 animate-spin" /> : 'Set'}
-        </Button>
-      </form>
-      {error && <div className="text-xs text-red-600">{error}</div>}
+      {zipCode && (
+        <div className="text-xs text-muted-foreground">ZIP {zipCode}</div>
+      )}
       <div className="flex flex-col gap-y-0.5">
         <div className="flex justify-between">
           <span className="text-gray-400">Sunrise</span>

--- a/src/components/WeeklyForecast.tsx
+++ b/src/components/WeeklyForecast.tsx
@@ -116,7 +116,6 @@ const WeeklyForecast = ({
           currentLocation={currentLocation || null}
           stationName={stationName || null}
           stationId={stationId || null}
-          showZipCode={false}
         />
       </CardHeader>
       <CardContent>


### PR DESCRIPTION
## Summary
- keep sunrise/sunset card static with optional ZIP display
- hide ZIP code in other cards by default
- pass saved ZIP into SunCard
- adjust weekly forecast to use new LocationDisplay default

## Testing
- `npm run lint`
- `npm run build`
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e9143b5cc832d81f9c90a8de7c866