### PR TITLE
Add NOAA tide map link

### DIFF
--- a/src/components/settings/SettingsList.tsx
+++ b/src/components/settings/SettingsList.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import SettingsItem from './SettingsItem';
-import { FileText, Mail } from 'lucide-react';
+import { FileText, Mail, Globe } from 'lucide-react';
 
 const SettingsList = () => {
   return (
@@ -26,6 +26,18 @@ const SettingsList = () => {
             'mailto:moontidesite@gmail.com?subject=' +
               encodeURIComponent('Moontide App Feedback'),
             '_blank'
+          )
+        }
+      />
+      <SettingsItem
+        icon={Globe}
+        title="🌐 View NOAA Tide Station Map"
+        subtitle="Explore tidal stations near you"
+        onClick={() =>
+          window.open(
+            'https://tidesandcurrents.noaa.gov/map/',
+            '_blank',
+            'noopener,noreferrer'
           )
         }
       />


### PR DESCRIPTION
## Summary
- add a new `SettingsItem` linking to the NOAA tide station map

## Testing
- `npm run lint`
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ee4667c58832da1f1a062e7ea8704