### PR TITLE
Fix build workflow artifact step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
 
       # 6) Upload artifact
       - name: Upload site.zip
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: site.zip
           path: site.zip


### PR DESCRIPTION
## Summary
- update GitHub Actions build workflow to use `actions/upload-artifact@v4`

## Testing
- `npm test` *(fails: `vitest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_688154b3f74c832d8e2f16a0d5dd3060