### PR TITLE
Add Android debug build artifact

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,15 +29,37 @@ jobs:
       - name: Build production
         run: npm run build
 
-      # 5) Package site
+      # 5) Set up JDK for Android build
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+
+      # 6) Set up Android SDK
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@v3
+
+      # 7) Build Android debug APK
+      - name: Build Android APK
+        run: npm run android:debug
+
+      # 8) Package site
       - name: Compress output
         run: |
           cd dist
           zip -r ../site.zip .
-
-      # 6) Upload artifact
+      
+      # 9) Upload site artifact
       - name: Upload site.zip
         uses: actions/upload-artifact@v4
         with:
           name: site.zip
           path: site.zip
+
+      # 10) Upload debug APK artifact
+      - name: Upload app-debug.apk
+        uses: actions/upload-artifact@v4
+        with:
+          name: app-debug.apk
+          path: android/app/build/outputs/apk/debug/app-debug.apk


### PR DESCRIPTION
## Summary
- build Android debug APK in CI
- set up Java & Android SDK in the workflow
- upload generated `app-debug.apk` artifact

## Testing
- `npm test` *(fails: `vitest: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_688170cb8f60832d81266b6603d95817