### PR TITLE
Add swipe navigation to calendar and adjust build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,20 +44,7 @@ jobs:
       - name: Build Android APK
         run: npm run android:debug
 
-      # 8) Package site
-      - name: Compress output
-        run: |
-          cd dist
-          zip -r ../site.zip .
-      
-      # 9) Upload site artifact
-      - name: Upload site.zip
-        uses: actions/upload-artifact@v4
-        with:
-          name: site.zip
-          path: site.zip
-
-      # 10) Upload debug APK artifact
+      # 8) Upload debug APK artifact
       - name: Upload app-debug.apk
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
## Summary
- enable swipe gestures to change calendar month
- keep arrow buttons as is
- remove site.zip packaging from build workflow

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68824a98314c832d9d2cdec082b0d75b