### PR TITLE
Add calendar swipe animations

### DIFF
--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -102,20 +102,30 @@ export default {
 					'0%, 100%': { transform: 'translateY(0)' },
 					'50%': { transform: 'translateY(-10px)' }
 				},
-				'wave': {
-					'0%': { transform: 'translateX(0) translateZ(0) scaleY(1)' },
-					'50%': { transform: 'translateX(-25%) translateZ(0) scaleY(0.8)' },
-					'100%': { transform: 'translateX(-50%) translateZ(0) scaleY(1)' }
-				}
-			},
-			animation: {
-				'accordion-down': 'accordion-down 0.2s ease-out',
-				'accordion-up': 'accordion-up 0.2s ease-out',
-				'pulse-subtle': 'pulse-subtle 3s ease-in-out infinite',
-				'float': 'float 6s ease-in-out infinite',
-				'wave': 'wave 12s linear infinite'
-			}
-		}
-	},
+                                'wave': {
+                                        '0%': { transform: 'translateX(0) translateZ(0) scaleY(1)' },
+                                        '50%': { transform: 'translateX(-25%) translateZ(0) scaleY(0.8)' },
+                                        '100%': { transform: 'translateX(-50%) translateZ(0) scaleY(1)' }
+                                },
+                                'calendar-slide-left': {
+                                        from: { transform: 'translateX(100%)' },
+                                        to: { transform: 'translateX(0)' }
+                                },
+                                'calendar-slide-right': {
+                                        from: { transform: 'translateX(-100%)' },
+                                        to: { transform: 'translateX(0)' }
+                                }
+                        },
+                        animation: {
+                                'accordion-down': 'accordion-down 0.2s ease-out',
+                                'accordion-up': 'accordion-up 0.2s ease-out',
+                                'pulse-subtle': 'pulse-subtle 3s ease-in-out infinite',
+                                'float': 'float 6s ease-in-out infinite',
+                                'wave': 'wave 12s linear infinite',
+                                'calendar-slide-left': 'calendar-slide-left 0.3s ease-out',
+                                'calendar-slide-right': 'calendar-slide-right 0.3s ease-out'
+                        }
+                }
+       },
        plugins: [animatePlugin],
 } satisfies Config;


### PR DESCRIPTION
## Summary
- add swipe animation state to calendar component
- create custom tailwind animations for calendar swiping
- trigger swipe animations on month changes

## Testing
- `npm run lint`
- `npm test` *(fails: `vitest` not found)*
- `npm run android:debug` *(fails: network access blocked)*


------
https://chatgpt.com/codex/tasks/task_e_68825a77fa1c832d95ec798867457f30