### PR TITLE
Fix calendar swipe animation

### DIFF
--- a/src/components/ui/calendar.tsx
+++ b/src/components/ui/calendar.tsx
@@ -51,15 +51,18 @@ function Calendar({
       onTouchStart={handleTouchStart}
       onTouchEnd={handleTouchEnd}
       onAnimationEnd={() => setSwipeDirection(null)}
+      className={cn(
+        swipeDirection === "next" && "calendar-animate-next",
+        swipeDirection === "prev" && "calendar-animate-prev"
+      )}
     >
+      <style>{`
+        .calendar-animate-next .rdp-months { animation: calendar-slide-left 0.3s ease-out; }
+        .calendar-animate-prev .rdp-months { animation: calendar-slide-right 0.3s ease-out; }
+      `}</style>
       <DayPicker
         showOutsideDays={showOutsideDays}
-        className={cn(
-          "p-3 pointer-events-auto",
-          className,
-          swipeDirection === "next" && "animate-calendar-slide-left",
-          swipeDirection === "prev" && "animate-calendar-slide-right"
-        )}
+        className={cn("p-3 pointer-events-auto", className)}
         classNames={{
           months: "flex flex-col sm:flex-row space-y-4 sm:space-x-4 sm:space-y-0",
           month: "space-y-4",


### PR DESCRIPTION
## Summary
- prevent header from sliding with calendar
- add internal styles for animating the months container

## Testing
- `npm run lint`
- `npm test` *(fails: vitest not found)*
- `npm run android:debug` *(fails: could not access registry)*

------
https://chatgpt.com/codex/tasks/task_e_688286207764832da8a4fd8c45e93206