### PR TITLE
Configure Capacitor app id

### DIFF
--- a/capacitor.config.ts
+++ b/capacitor.config.ts
@@ -2,7 +2,7 @@
 import { CapacitorConfig } from '@capacitor/cli';
 
 const config: CapacitorConfig = {
-  appId: 'com.example.moontide',   // ← use your real ID
+  appId: 'com.moontide.app',
   appName: 'MoonTide',
   webDir: 'dist',
   bundledWebRuntime: false,


### PR DESCRIPTION
## Summary
- update `capacitor.config.ts` to use `com.moontide.app`

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_688cb66a9a0c832d9bccb07a558bcb03