### PR TITLE
Fix Gradle build by unifying Kotlin version

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,6 +1,8 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
+
+    ext.kotlin_version = "1.8.22"
     
     repositories {
         google()
@@ -21,6 +23,14 @@ allprojects {
     repositories {
         google()
         mavenCentral()
+    }
+
+    configurations.all {
+        resolutionStrategy.eachDependency { details ->
+            if (details.requested.group == 'org.jetbrains.kotlin') {
+                details.useVersion(kotlin_version)
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- enforce Kotlin version 1.8.22 across all modules

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_688d156ca198832d89800513e861a171