### PR TITLE
Fix Android release build resources

### DIFF
--- a/android/app/src/main/res/values/colors.xml
+++ b/android/app/src/main/res/values/colors.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="colorPrimary">#6200EE</color>
+    <color name="colorPrimaryDark">#3700B3</color>
+    <color name="colorAccent">#03DAC5</color>
+</resources>


### PR DESCRIPTION
## Summary
- add missing colors.xml file for Android

## Testing
- `./gradlew bundleRelease` *(fails: unable to download due to proxy 403)*

------
https://chatgpt.com/codex/tasks/task_e_688d19e31eb0832d88bf0fa6f4b7486e